### PR TITLE
Add PlayerTracker TrackBelowY option

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -85,6 +85,7 @@ PlayerTracker:
   Tracker: '&ePlayer Tracker'
   Message: '&b&lTarget: &3%nearestplayer% &b&lDistance: &3%distance%'
   NoneOnline: '&cNo Players Online'
+  TrackBelowY: 128
 Soups:
   Name: '&aRegenerative Soups &7(Right Click)'
   RemoveAfterUse: true

--- a/src/com/planetgallium/kitpvp/Game.java
+++ b/src/com/planetgallium/kitpvp/Game.java
@@ -61,6 +61,7 @@ public class Game extends JavaPlugin implements Listener {
 		pm.registerEvents(new SignListener(resources), this);
 		pm.registerEvents(new AliasCommand(), this);
 		pm.registerEvents(new AbilityListener(arena, resources), this);
+		pm.registerEvents(new TrackerListener(this), this);
 		pm.registerEvents(getArena().getKillStreaks(), this);
 		
 		getConfig().options().copyDefaults(true);

--- a/src/com/planetgallium/kitpvp/listener/ItemListener.java
+++ b/src/com/planetgallium/kitpvp/listener/ItemListener.java
@@ -18,7 +18,6 @@ import org.bukkit.event.entity.EntityDamageEvent.DamageCause;
 import org.bukkit.event.entity.EntityShootBowEvent;
 import org.bukkit.event.entity.ProjectileLaunchEvent;
 import org.bukkit.event.player.PlayerInteractEvent;
-import org.bukkit.event.player.PlayerItemHeldEvent;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.meta.ItemMeta;
 import org.bukkit.potion.Potion;
@@ -342,56 +341,6 @@ public class ItemListener implements Listener {
 						}
 							
 					}
-					
-				}
-				
-			}
-			
-		}
-		
-	}
-	
-	@EventHandler
-	public void onItemHeld(PlayerItemHeldEvent e) {
-		
-		Player p = e.getPlayer();
-		
-		if (Toolkit.inArena(p)) {
-			
-			int i = e.getNewSlot();
-			ItemStack item = p.getInventory().getItem(i);
-			
-			if (item != null) {
-				
-				if (item.getType() == XMaterial.COMPASS.parseMaterial()) {
-					
-					new BukkitRunnable() {
-						
-						@Override
-						public void run() {
-							
-	            			if ((p.getWorld().getPlayers().size() > 1) && (Bukkit.getServer().getPlayer(Toolkit.getNearestPlayer(p)[0]).getLocation().getY() < Game.getInstance().getConfig().getInt("PlayerTracker.TrackBelowY"))) {
-		                		
-	            				Double distance = Double.parseDouble(Toolkit.getNearestPlayer(p)[1]);
-	            				distance = Math.round(distance * 10.0) / 10.0;
-		            			
-	            				ItemMeta meta = item.getItemMeta();
-		            			meta.setDisplayName(Config.getS("PlayerTracker.Message").replace("%nearestplayer%", Toolkit.getNearestPlayer(p)[0]).replace("%distance%", String.valueOf(distance)));
-		            			item.setItemMeta(meta);
-		            			p.setCompassTarget(Bukkit.getServer().getPlayer(Toolkit.getNearestPlayer(p)[0]).getLocation());
-		            			
-		                	} else {
-		                		
-		                		ItemMeta meta = item.getItemMeta();
-		                		meta.setDisplayName(Game.getInstance().getConfig().getString("PlayerTracker.NoneOnline").replaceAll("&", "§"));
-		                		item.setItemMeta(meta);
-		                		cancel();
-		                		
-		                	}
-							
-						}
-						
-					}.runTaskTimer(Game.getInstance(), 0L, 20L);		
 					
 				}
 				

--- a/src/com/planetgallium/kitpvp/listener/ItemListener.java
+++ b/src/com/planetgallium/kitpvp/listener/ItemListener.java
@@ -370,7 +370,7 @@ public class ItemListener implements Listener {
 						@Override
 						public void run() {
 							
-	            			if (p.getWorld().getPlayers().size() > 1) {
+	            			if ((p.getWorld().getPlayers().size() > 1) && (Bukkit.getServer().getPlayer(Toolkit.getNearestPlayer(p)[0]).getLocation().getY() < Game.getInstance().getConfig().getInt("PlayerTracker.TrackBelowY"))) {
 		                		
 	            				Double distance = Double.parseDouble(Toolkit.getNearestPlayer(p)[1]);
 	            				distance = Math.round(distance * 10.0) / 10.0;

--- a/src/com/planetgallium/kitpvp/listener/TrackerListener.java
+++ b/src/com/planetgallium/kitpvp/listener/TrackerListener.java
@@ -1,0 +1,83 @@
+package com.planetgallium.kitpvp.listener;
+
+import org.bukkit.Bukkit;
+import org.bukkit.entity.Player;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+import org.bukkit.event.player.PlayerItemHeldEvent;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.meta.ItemMeta;
+import org.bukkit.scheduler.BukkitRunnable;
+
+import com.planetgallium.kitpvp.Game;
+import com.planetgallium.kitpvp.util.Config;
+import com.planetgallium.kitpvp.util.Toolkit;
+import com.planetgallium.kitpvp.util.XMaterial;
+
+public class TrackerListener implements Listener {
+
+	private Game plugin;
+	
+	public TrackerListener(Game plugin) {
+		this.plugin = plugin;
+	}
+	
+	@EventHandler
+	public void onCompassHeld(PlayerItemHeldEvent event) {
+		
+		Player player = event.getPlayer();
+		
+		if (Toolkit.inArena(player)) {
+			
+			ItemStack item = player.getInventory().getItem(event.getNewSlot());
+			
+			if (item != null) {
+				
+				if (item.getType() == XMaterial.COMPASS.parseMaterial()) {
+					
+					new BukkitRunnable() {
+						
+						@Override
+						public void run() {
+							
+							if (player.getWorld().getPlayers().size() > 1) {
+								
+								String[] nearestData = Toolkit.getNearestPlayer(player);
+								Player nearestPlayer = Bukkit.getPlayer(nearestData[0]);
+								double nearestDistance = Double.parseDouble(nearestData[1]);
+								
+								if (nearestPlayer.getLocation().getY() < plugin.getConfig().getInt("PlayerTracker.TrackBelowY")) {
+									
+									nearestDistance = Math.round(nearestDistance * 10.0) / 10.0;
+									
+		            				ItemMeta meta = item.getItemMeta();
+			            			meta.setDisplayName(Config.getS("PlayerTracker.Message").replace("%nearestplayer%", nearestPlayer.getName()).replace("%distance%", String.valueOf(nearestDistance)));
+			            			item.setItemMeta(meta);
+			            			
+			            			player.setCompassTarget(nearestPlayer.getLocation());
+									
+								}
+								
+							} else {
+								
+		                		ItemMeta meta = item.getItemMeta();
+		                		meta.setDisplayName(Config.tr(plugin.getConfig().getString("PlayerTracker.NoneOnline")));
+		                		item.setItemMeta(meta);
+		                		
+		                		cancel();
+								
+							}
+							
+						}
+						
+					}.runTaskTimer(plugin, 0L, 20L);
+					
+				}
+				
+			}
+			
+		}
+		
+	}
+	
+}


### PR DESCRIPTION
This is a new feature for PlayerTracker to only track players below certain Y-level 