### PR TITLE
Update SoupListener.java

### DIFF
--- a/src/main/java/com/planetgallium/kitpvp/listener/SoupListener.java
+++ b/src/main/java/com/planetgallium/kitpvp/listener/SoupListener.java
@@ -56,6 +56,9 @@ public class SoupListener implements Listener {
 									if (count < Config.getI("GiveSoupOnKill.Amount")) {
 										killer.sendMessage(Config.getS("GiveSoupOnKill.NoSpace").replace("%amount%", String.valueOf((Config.getI("GiveSoupOnKill.Amount") - count))));
 									}
+									else{
+										count = Config.getI("GiveSoupOnKill.Amount");
+									}
 									
 									for (int r = 0; r < count; r++) {
 										killer.getInventory().addItem(new ItemStack(XMaterial.MUSHROOM_STEW.parseItem()));


### PR DESCRIPTION
Fix bug of players getting too many soups on kill.

this is done by checking if count is larger than the amount set in config, if count is larger then it sets count to the amount set in config.