### PR TITLE
Add config option for changing player gamemode set in Arena.addPlayer

### DIFF
--- a/src/main/java/com/planetgallium/kitpvp/game/Arena.java
+++ b/src/main/java/com/planetgallium/kitpvp/game/Arena.java
@@ -71,7 +71,7 @@ public class Arena {
 			p.setFireTicks(0);
 		}
 
-		p.setGameMode(GameMode.SURVIVAL);
+		p.setGameMode(GameMode.valueOf(config.getString("Arena.PlayerGamemode")));
 		
 		if (config.getBoolean("Arena.FancyDeath")) {
 			p.setHealth(20.0);

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -121,6 +121,7 @@ Arena:
   ResetKillStreakOnLeave: true
   ToSpawnOnJoin: true
   DeathParticles: true
+  PlayerGamemode: "ADVENTURE"
 Other:
   AutomaticallyAddKitToMenu: true
 Spawn:


### PR DESCRIPTION
This will allow the end user to choose between survival and adventure mode being used in arenas. Also defaults to adventure mode now.