### PR TITLE
Move maven-shade-plugin outputFile into a profile

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -31,7 +31,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-shade-plugin</artifactId>
-                <version>3.2.1</version>
+                <version>3.2.4</version>
                 <configuration>
                     <relocations>
                         <relocation>
@@ -66,7 +66,6 @@
                         <configuration>
                             <createDependencyReducedPom>false</createDependencyReducedPom>
                             <shadedArtifactAttached>false</shadedArtifactAttached>
-                            <outputFile>/Users/nico/Developer/SpigotL/plugins/${project.artifactId}.jar</outputFile>
                         </configuration>
                     </execution>
                 </executions>
@@ -79,6 +78,26 @@
             </resource>
         </resources>
     </build>
+
+    <profiles>
+        <profile>
+            <id>dev</id>
+            <activation>
+                <activeByDefault>false</activeByDefault>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-shade-plugin</artifactId>
+                        <configuration>
+                            <outputFile>/Users/nico/Developer/SpigotL/plugins/${project.artifactId}.jar</outputFile>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
 
     <dependencies>
         <dependency>


### PR DESCRIPTION
This will make it easier for others to contribute to your repository since they won't find the /Users/nico/ directory created on the drive.

For your own purposes, you can build with `mvn -Pdev`, which will set the outputFile as you desire.

Since I know it is not fun to change a personal workflow, and if you think it is too burdensome to add `-Pdev` to the end of the command, you can commit a bash script which adds that property for you, i.e. by running `mvn $@ -Pdev`. Failing that, you can enable activationByDefault in the profile, but I don't recommend doing so, as that would still make the build unwelcoming to newcomers.