### PR TITLE
Add github workflow to automatically check pushes and PRs

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -1,0 +1,31 @@
+name: Java CI
+
+on:
+  push:
+    branches: [ '*' ]
+  pull_request: {}
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    if: ${{ github.event_name != 'pull_request' || github.repository != github.event.pull_request.head.repo.full_name }}
+    steps:
+    - uses: actions/checkout@v2
+    - name: Cache Maven packages
+      uses: actions/cache@v2
+      with:
+        path: ~/.m2
+        key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
+        restore-keys: ${{ runner.os }}-m2
+    - name: Set up JDK 16
+      uses: actions/setup-java@v2
+      with:
+        java-version: 16
+        distribution: 'zulu'
+    - name: Build with Maven
+      run: mvn clean -B -U verify
+    - run: mkdir staging && cp target/*.jar staging
+    - uses: actions/upload-artifact@v2
+      with:
+        name: KitPvP
+        path: staging


### PR DESCRIPTION
If, eventually, you come to rely on this workflow, I suggest setting the `release` property of the maven-compiler-plugin which translates to the `--release` compiler flag. The "release" option replaces source/target/ and will provide a guarantee that your jars have the JDK compatibility you seek.