### PR TITLE
Merge next-update into master

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.planetgallium</groupId>
     <artifactId>KitPvP</artifactId>
-    <version>2.1.8</version>
+    <version>2.1.9</version>
     <packaging>jar</packaging>
 
     <name>${project.artifactId}</name>

--- a/src/main/java/com/planetgallium/kitpvp/command/MainCommand.java
+++ b/src/main/java/com/planetgallium/kitpvp/command/MainCommand.java
@@ -488,8 +488,6 @@ public class MainCommand implements CommandExecutor {
 
     private void clearKit(Player p) {
 
-        CacheManager.getWitchPotionUsers().remove(p.getName());
-
         p.getInventory().setArmorContents(null);
         p.getInventory().clear();
 

--- a/src/main/java/com/planetgallium/kitpvp/command/MainCommand.java
+++ b/src/main/java/com/planetgallium/kitpvp/command/MainCommand.java
@@ -488,6 +488,8 @@ public class MainCommand implements CommandExecutor {
 
     private void clearKit(Player p) {
 
+        CacheManager.getWitchPotionUsers().remove(p.getName());
+
         p.getInventory().setArmorContents(null);
         p.getInventory().clear();
 

--- a/src/main/java/com/planetgallium/kitpvp/game/Arena.java
+++ b/src/main/java/com/planetgallium/kitpvp/game/Arena.java
@@ -95,7 +95,6 @@ public class Arena {
 	public void removePlayer(Player p) {
 
 		CacheManager.getPlayerAbilityCooldowns(p.getName()).clear();
-		CacheManager.getWitchPotionUsers().remove(p.getName());
 
 		for (PotionEffect effect : p.getActivePotionEffects()) {
 			p.removePotionEffect(effect.getType());

--- a/src/main/java/com/planetgallium/kitpvp/game/Leaderboards.java
+++ b/src/main/java/com/planetgallium/kitpvp/game/Leaderboards.java
@@ -36,6 +36,11 @@ public class Leaderboards {
         if (!isValidCacheType(key)) return;
 
         List<PlayerEntry> leaderboard = getLeaderboard(key);
+
+        if (leaderboard.size() == 0) {
+            return;
+        }
+        
         PlayerEntry lowestRankingPlayer = leaderboard.get(leaderboard.size() - 1);
 
         // If updated player entry has a higher data value than the lowest ranking player in a leaderboard

--- a/src/main/java/com/planetgallium/kitpvp/game/Stats.java
+++ b/src/main/java/com/planetgallium/kitpvp/game/Stats.java
@@ -50,9 +50,10 @@ public class Stats {
         }
     }
 
-    public void addExperience(Player p, int experience) {
+    public void addExperience(Player p, int experienceToAdd) {
         if (levels.getBoolean("Levels.Levels.Enabled")) {
-            setStat("experience", p.getName(), experience);
+            int currentExperience = getStat("experience", p.getName());
+            setStat("experience", p.getName(), currentExperience + experienceToAdd);
             if (getStat("experience", p.getName()) >= getRegularOrRelativeNeededExperience(p.getName())) {
                 levelUp(p);
                 Bukkit.getPluginManager().callEvent(new PlayerLevelUpEvent(p, getStat("level", p.getName())));

--- a/src/main/java/com/planetgallium/kitpvp/listener/ItemListener.java
+++ b/src/main/java/com/planetgallium/kitpvp/listener/ItemListener.java
@@ -1,11 +1,12 @@
 package com.planetgallium.kitpvp.listener;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Random;
 
 import com.cryptomorin.xseries.XMaterial;
 import com.cryptomorin.xseries.XSound;
 import com.planetgallium.kitpvp.api.Kit;
-import com.planetgallium.kitpvp.util.CacheManager;
 import com.planetgallium.kitpvp.util.Resource;
 import org.bukkit.*;
 import org.bukkit.configuration.ConfigurationSection;
@@ -84,18 +85,7 @@ public class ItemListener implements Listener {
 
 				if (isAbilityItem(p, "Witch", item)) {
 
-					Potion potion = new Potion(pickPotion(), 1);
-					potion.setSplash(true);
-
-					ItemStack potionStack = potion.toItemStack(1);
-//					ItemMeta potionMeta = potionStack.getItemMeta();
-//
-//					potionMeta.setLocalizedName("WitchPotion");
-//					potionStack.setItemMeta(potionMeta);
-
-					CacheManager.getWitchPotionUsers().add(p.getName());
-
-					Toolkit.setMainHandItem(p, potionStack);
+					Toolkit.setMainHandItem(p, createWitchPotion());
 
 				}
 
@@ -491,25 +481,22 @@ public class ItemListener implements Listener {
 
 				if (e.getEntity().getType() == EntityType.SPLASH_POTION) {
 
-					if (CacheManager.getWitchPotionUsers().contains(shooter.getName())) {
+					if (itemThrown.hasItemMeta() && itemThrown.getItemMeta().hasLore() &&
+							itemThrown.getItemMeta().getLore().get(0).equals("§8X")) {
 
 						int slot = shooter.getInventory().getHeldItemSlot();
 						Kit playerKit = arena.getKits().getKitOfPlayer(shooter.getName());
 
 						if (playerKit != null) {
 
-							Potion potion = new Potion(pickPotion(), 1);
-							potion.setSplash(true);
-
-							ItemStack potionStack = potion.toItemStack(1);
+							ItemStack potionStack = createWitchPotion();
 
 							new BukkitRunnable() {
 
 								@Override
 								public void run() {
 
-									if (!arena.getKits().hasKit(shooter.getName()) ||
-											!CacheManager.getWitchPotionUsers().contains(shooter.getName())) {
+									if (!arena.getKits().hasKit(shooter.getName())) {
 										return;
 									}
 
@@ -544,6 +531,23 @@ public class ItemListener implements Listener {
 			
 		}
 		
+	}
+
+	private ItemStack createWitchPotion() {
+
+		Potion potion = new Potion(pickPotion(), 1);
+		potion.setSplash(true);
+
+		ItemStack potionStack = potion.toItemStack(1);
+		ItemMeta potionMeta = potionStack.getItemMeta();
+
+		List<String> lore = new ArrayList<>();
+		lore.add(Toolkit.translate("&8X"));
+		potionMeta.setLore(lore);
+
+		potionStack.setItemMeta(potionMeta);
+		return potionStack;
+
 	}
 	
 	@EventHandler

--- a/src/main/java/com/planetgallium/kitpvp/listener/ItemListener.java
+++ b/src/main/java/com/planetgallium/kitpvp/listener/ItemListener.java
@@ -496,7 +496,7 @@ public class ItemListener implements Listener {
 						int slot = shooter.getInventory().getHeldItemSlot();
 						Kit playerKit = arena.getKits().getKitOfPlayer(shooter.getName());
 
-						if (playerKit != null && playerKit.getName().equalsIgnoreCase("Witch")) {
+						if (playerKit != null) {
 
 							Potion potion = new Potion(pickPotion(), 1);
 							potion.setSplash(true);
@@ -509,21 +509,17 @@ public class ItemListener implements Listener {
 								public void run() {
 
 									if (!arena.getKits().hasKit(shooter.getName()) ||
-										!arena.getKits().getKitOfPlayer(shooter.getName()).getName().equals("Witch")) {
+											!CacheManager.getWitchPotionUsers().contains(shooter.getName())) {
 										return;
 									}
 
-									if (CacheManager.getWitchPotionUsers().contains(shooter.getName())) {
+									shooter.getInventory().setItem(slot, potionStack);
 
-										shooter.getInventory().setItem(slot, potionStack);
-
-										if (abilities.getBoolean("Abilities.Witch.Message.Enabled")) {
-											shooter.sendMessage(Toolkit.translate(abilities.getString("Abilities.Witch.Message.Message")));
-										}
-
-										XSound.play(shooter, abilities.getString("Abilities.Witch.Sound.Sound") + ", 1, " + abilities.getInt("Abliities.Witch.Sound.Pitch"));
-
+									if (abilities.getBoolean("Abilities.Witch.Message.Enabled")) {
+										shooter.sendMessage(Toolkit.translate(abilities.getString("Abilities.Witch.Message.Message")));
 									}
+
+									XSound.play(shooter, abilities.getString("Abilities.Witch.Sound.Sound") + ", 1, " + abilities.getInt("Abliities.Witch.Sound.Pitch"));
 
 								}
 

--- a/src/main/java/com/planetgallium/kitpvp/listener/TrackerListener.java
+++ b/src/main/java/com/planetgallium/kitpvp/listener/TrackerListener.java
@@ -1,9 +1,7 @@
 package com.planetgallium.kitpvp.listener;
 
 import com.cryptomorin.xseries.XMaterial;
-import com.planetgallium.kitpvp.util.CacheManager;
 import com.planetgallium.kitpvp.util.Resources;
-import org.bukkit.Bukkit;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
@@ -17,81 +15,84 @@ import com.planetgallium.kitpvp.util.Toolkit;
 
 public class TrackerListener implements Listener {
 
-	private Resources resources;
+	private final Game plugin;
+	private final Resources resources;
 	
 	public TrackerListener(Game plugin) {
+		this.plugin = plugin;
 		this.resources = plugin.getResources();
 	}
 	
 	@EventHandler
 	public void onCompassHeld(PlayerItemHeldEvent event) {
-		
+
+		if (!Toolkit.inArena(event.getPlayer())) {
+			return;
+		}
+
 		Player player = event.getPlayer();
-		
-		if (Toolkit.inArena(player)) {
+		ItemStack itemHeld = player.getInventory().getItem(event.getNewSlot());
 
-			ItemStack item = player.getInventory().getItem(event.getNewSlot());
+		if (itemHeld != null && itemHeld.getType() == XMaterial.COMPASS.parseMaterial()) {
 
-			if (item != null && item.getType() == XMaterial.COMPASS.parseMaterial()) {
+			new BukkitRunnable() {
 
-				if (!CacheManager.getCompassUsers().contains(player.getName())) {
+				@Override
+				public void run() {
 
-					new BukkitRunnable() {
+					if (!player.isOnline()) { // if the player using the compass leaves the server
+						cancel();
+						return;
+					}
 
-						@Override
-						public void run() {
-
-							if (!player.isOnline()) {
-								CacheManager.getCompassUsers().remove(player.getName());
-								cancel();
-								return;
-							}
-
-							String[] nearestData = Toolkit.getNearestPlayer(player, resources.getConfig().getInt("PlayerTracker.TrackBelowY"));
-
-							if (player.getWorld().getPlayers().size() > 1 && nearestData != null) {
-
-								Player nearestPlayer = Bukkit.getPlayer(nearestData[0]);
-								double nearestDistance = Double.parseDouble(nearestData[1]);
-
-								if (nearestPlayer == null || !nearestPlayer.isOnline()) {
-									CacheManager.getCompassUsers().remove(player.getName());
-									cancel();
-									return;
-								}
-
-								nearestDistance = Math.round(nearestDistance * 10.0) / 10.0;
-
-								ItemMeta meta = item.getItemMeta();
-								meta.setDisplayName(resources.getConfig().getString("PlayerTracker.Message")
-										.replace("%nearestplayer%", nearestPlayer.getName())
-										.replace("%distance%", String.valueOf(nearestDistance)));
-								item.setItemMeta(meta);
-
-								player.setCompassTarget(nearestPlayer.getLocation());
-
-								CacheManager.getCompassUsers().add(player.getName());
-
-							} else {
-
-								ItemMeta meta = item.getItemMeta();
-								meta.setDisplayName(resources.getConfig().getString("PlayerTracker.NoneOnline"));
-								item.setItemMeta(meta);
-
-								cancel();
-
-							}
-
+					if (resources.getConfig().getBoolean("PlayerTracker.RefreshOnlyWhenHeld")) {
+						ItemStack itemInHand = Toolkit.getMainHandItem(player);
+						if (itemInHand == null || itemInHand.getType() != XMaterial.COMPASS.parseMaterial()) {
+							cancel();
+							return;
 						}
+					}
 
-					}.runTaskTimer(Game.getInstance(), 0L, 20L);
+					String[] nearestPlayerData = null;
+
+					if (player.getWorld().getPlayers().size() == 1) {
+						cancel();
+					} else {
+						nearestPlayerData = Toolkit.getNearestPlayer(player,
+												 resources.getConfig().getInt("PlayerTracker.TrackBelowY"));
+					}
+
+					updateTrackingCompass(player, itemHeld, nearestPlayerData);
 
 				}
 
-			}
-			
+			}.runTaskTimer(plugin, 0L, 20L);
+
 		}
 		
+	}
+
+	private void updateTrackingCompass(Player player, ItemStack compass, String[] nearestPlayerData) {
+
+		ItemMeta compassMeta = compass.getItemMeta();
+
+		if (nearestPlayerData != null) {
+			Player nearestPlayer = Toolkit.getPlayer(player.getWorld(), nearestPlayerData[0]);
+			double nearestPlayerDistance = Toolkit.round(Double.parseDouble(nearestPlayerData[1]), 1);
+
+			if (nearestPlayer != null && nearestPlayer.isOnline()) {
+				compassMeta.setDisplayName(resources.getConfig().getString("PlayerTracker.Message")
+												   .replace("%nearestplayer%", nearestPlayer.getName())
+												   .replace("%distance%", String.valueOf(nearestPlayerDistance)));
+
+				player.setCompassTarget(nearestPlayer.getLocation());
+			}
+		} else {
+			compassMeta.setDisplayName(resources.getConfig().getString("PlayerTracker.NoneOnline"));
+		}
+
+		compass.setItemMeta(compassMeta);
+
 	}
 	
 }

--- a/src/main/java/com/planetgallium/kitpvp/listener/TrackerListener.java
+++ b/src/main/java/com/planetgallium/kitpvp/listener/TrackerListener.java
@@ -1,6 +1,7 @@
 package com.planetgallium.kitpvp.listener;
 
 import com.cryptomorin.xseries.XMaterial;
+import com.planetgallium.kitpvp.game.Arena;
 import com.planetgallium.kitpvp.util.Resources;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
@@ -16,10 +17,12 @@ import com.planetgallium.kitpvp.util.Toolkit;
 public class TrackerListener implements Listener {
 
 	private final Game plugin;
+	private final Arena arena;
 	private final Resources resources;
 	
 	public TrackerListener(Game plugin) {
 		this.plugin = plugin;
+		this.arena = plugin.getArena();
 		this.resources = plugin.getResources();
 	}
 	
@@ -40,7 +43,8 @@ public class TrackerListener implements Listener {
 				@Override
 				public void run() {
 
-					if (!player.isOnline()) { // if the player using the compass leaves the server
+					// if the player using the compass leaves the server or no longer has a kit
+					if (!player.isOnline() || !arena.getKits().hasKit(player.getName())) {
 						cancel();
 						return;
 					}

--- a/src/main/java/com/planetgallium/kitpvp/util/CacheManager.java
+++ b/src/main/java/com/planetgallium/kitpvp/util/CacheManager.java
@@ -9,7 +9,6 @@ public class CacheManager {
     private static final Map<String, String> usernameToUUID = new HashMap<>();
     private static final Map<String, Kit> kitCache = new HashMap<>();
     private static final Map<String, Menu> previewMenuCache = new HashMap<>();
-    private static final Set<String> compassUsers = new HashSet<>();
     private static final Map<String, Map<String, Long>> abilityCooldowns = new HashMap<>();
     private static final Map<String, PlayerData> statsCache = new HashMap<>();
 
@@ -18,8 +17,6 @@ public class CacheManager {
     public static Map<String, Kit> getKitCache() { return kitCache; }
 
     public static Map<String, Menu> getPreviewMenuCache() { return previewMenuCache; }
-
-    public static Set<String> getCompassUsers() { return compassUsers; }
 
     public static Map<String, PlayerData> getStatsCache() { return statsCache; }
 
@@ -36,7 +33,6 @@ public class CacheManager {
     public static void clearCaches() {
         kitCache.clear();
         previewMenuCache.clear();
-        compassUsers.clear();
         abilityCooldowns.clear();
         // stats, usernameToUUID, and cache isn't here as of right now
     }

--- a/src/main/java/com/planetgallium/kitpvp/util/CacheManager.java
+++ b/src/main/java/com/planetgallium/kitpvp/util/CacheManager.java
@@ -11,7 +11,6 @@ public class CacheManager {
     private static final Map<String, Menu> previewMenuCache = new HashMap<>();
     private static final Set<String> compassUsers = new HashSet<>();
     private static final Map<String, Map<String, Long>> abilityCooldowns = new HashMap<>();
-    private static final Set<String> witchPotionUsers = new HashSet<>();
     private static final Map<String, PlayerData> statsCache = new HashMap<>();
 
     public static Map<String, String> getUUIDCache() { return usernameToUUID; }
@@ -21,8 +20,6 @@ public class CacheManager {
     public static Map<String, Menu> getPreviewMenuCache() { return previewMenuCache; }
 
     public static Set<String> getCompassUsers() { return compassUsers; }
-
-    public static Set<String> getWitchPotionUsers() { return witchPotionUsers; }
 
     public static Map<String, PlayerData> getStatsCache() { return statsCache; }
 
@@ -41,7 +38,7 @@ public class CacheManager {
         previewMenuCache.clear();
         compassUsers.clear();
         abilityCooldowns.clear();
-        // stats, usernameToUUID, and witchPotionUsers cache isn't here as of right now
+        // stats, usernameToUUID, and cache isn't here as of right now
     }
 
 }

--- a/src/main/java/com/planetgallium/kitpvp/util/Placeholders.java
+++ b/src/main/java/com/planetgallium/kitpvp/util/Placeholders.java
@@ -23,7 +23,7 @@ public class Placeholders extends PlaceholderExpansion {
 
 		placeholderAPItoBuiltIn.put("stats_kills", "%kills%");
 		placeholderAPItoBuiltIn.put("stats_deaths", "%deaths%");
-		placeholderAPItoBuiltIn.put("stats_kdr", "%kdr%");
+		placeholderAPItoBuiltIn.put("stats_kd", "%kd%");
 		placeholderAPItoBuiltIn.put("stats_experience", "%xp%");
 		placeholderAPItoBuiltIn.put("stats_level", "%level%");
 		placeholderAPItoBuiltIn.put("player_killstreak", "%streak%");
@@ -63,6 +63,12 @@ public class Placeholders extends PlaceholderExpansion {
 	}
 
 	public String translatePlaceholderAPIPlaceholders(String placeholderAPIIdentifier, String username) {
+
+		if (!placeholderAPItoBuiltIn.containsKey(placeholderAPIIdentifier)) {
+			Toolkit.printToConsole(String.format("&7[&b&lKIT-PVP&7] &cUnknown placeholder identifier [%s]. Please see plugin page.",
+												 placeholderAPIIdentifier));
+			return "invalid-placeholder";
+		}
 
 		return arena.replaceBuiltInPlaceholdersIfPresent(placeholderAPItoBuiltIn.get(placeholderAPIIdentifier), username);
 

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -69,6 +69,7 @@ PlayerTracker:
   Message: '&b&lTarget: &3%nearestplayer% &b&lDistance: &3%distance%'
   NoneOnline: '&cNo Players Online'
   TrackBelowY: 128
+  RefreshOnlyWhenHeld: true
 Soups:
   Name: '&aRegenerative Soups &7(Right Click)'
   RegenAmount: 6

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -1,7 +1,7 @@
 name: KitPvP
 author: Cervinakuy
 main: com.planetgallium.kitpvp.Game
-version: 2.1.8
+version: 2.1.9
 description: The ultimate all-in-one KitPvP plugin.
 website: https://www.spigotmc.org/resources/27107/
 softdepend: [PlaceholderAPI, WorldGuard]


### PR DESCRIPTION
Added RefreshOnlyWhenHeld under PlayerTracker to improve performance for smaller servers

Changed %kitpvp_stats_kdr% to %kitpvp_stats_kd%

Fixed KD PlaceholderAPI placeholder not working
Fixed Witch ability being triggered by any splash potion
Fixed ArrayIndexOutOfBoundsException error
Fixed being unable to gain more than 15 experience
Fixed Player Tracker not working after respawning, or other potential circumstances