### PR TITLE
Added configuration option to prevent hunger when no kit is selected if PreventHunger is false

### DIFF
--- a/src/main/java/com/planetgallium/kitpvp/listener/ArenaListener.java
+++ b/src/main/java/com/planetgallium/kitpvp/listener/ArenaListener.java
@@ -91,15 +91,23 @@ public class ArenaListener implements Listener {
 	
 	@EventHandler
 	public void onHunger(FoodLevelChangeEvent e) {
-		
+
 		Player p = (Player) e.getEntity();
-		
-		if (Toolkit.inArena(p) && config.getBoolean("Arena.PreventHunger")) {
-			
-			e.setCancelled(true);
-			
+
+		if (Toolkit.inArena(p)) {
+
+			if (config.getBoolean("Arena.PreventHunger")) {
+
+				e.setCancelled(true);
+
+			} else if (config.getBoolean("Arena.NoKitPreventHunger") && !arena.getKits().hasKit(p.getName())) {
+
+				e.setCancelled(true);
+
+			}
+
 		}
-		
+
 	}
 	
     @EventHandler

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -111,6 +111,7 @@ Arena:
   GiveItemsOnRespawn: true
   GiveItemsOnJoin: true
   NoKitProtection: true
+  NoKitPreventHunger: true
   FancyDeath: true
   ResetKillStreakOnLeave: true
   ToSpawnOnJoin: true


### PR DESCRIPTION
When PreventHunger is false in configuration, hunger will drop when no kit is selected. This PR adds a configuration option to prevent hunger only when no kit has been selected.

Requires wiki update if this is merged.