### PR TITLE
v2.2.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,14 +1,17 @@
 ![image](https://i.imgur.com/3MpRXfn.png)
 
 # KitPvP
-An all-in-one battle plugin built using customizable kits and features.
+The all-in-one battle plugin featuring custom kits, custom abilities, leaderboards, levels, kill streaks, and more.
 
 ## Support
+We use GitHub for plugin support, bug tracking, and any other topics related to KitPvP.
+
+Prior to contacting us via the below links, please ensure you have fully read the [KitPvP Wiki](https://github.com/cervinakuy/KitPvP/wiki).
+
+The below links require being logged into a GitHub account. 
 * [Ask a question](https://github.com/cervinakuy/KitPvP/issues/new?assignees=&labels=help+wanted&template=ask-for-assistance.md&title=)
 * [Report a bug](https://github.com/cervinakuy/KitPvP/issues/new?assignees=&labels=bug&template=report-a-bug.md&title=)
-* [Request a feature](https://github.com/cervinakuy/KitPvP/issues/new?assignees=&labels=feature+request&template=request-a-feature.md&title=)
 
 ## Quick Links
 * [Plugin Page](https://www.spigotmc.org/resources/27107/)
 * [Wiki](https://github.com/cervinakuy/KitPvP/wiki)
-* [Support Discord](https://discord.gg/Hfej6UR8Bk)

--- a/pom.xml
+++ b/pom.xml
@@ -39,6 +39,10 @@
                             <pattern>com.cryptomorin.xseries</pattern>
                             <shadedPattern>com.planetgallium.kitpvp</shadedPattern>
                         </relocation>
+                        <relocation>
+                            <pattern>com.mysql</pattern>
+                            <shadedPattern>com.planetgallium.sql</shadedPattern>
+                        </relocation>
                     </relocations>
                     <filters>
                         <filter>

--- a/pom.xml
+++ b/pom.xml
@@ -73,7 +73,6 @@
                         <configuration>
                             <createDependencyReducedPom>false</createDependencyReducedPom>
                             <shadedArtifactAttached>false</shadedArtifactAttached>
-                            <outputFile>/Users/nico/Developer/Spigot/Latest/plugins/${project.artifactId}.jar</outputFile>
                         </configuration>
                     </execution>
                 </executions>
@@ -86,6 +85,26 @@
             </resource>
         </resources>
     </build>
+
+    <profiles>
+        <profile>
+            <id>dev</id>
+            <activation>
+                <activeByDefault>false</activeByDefault>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-shade-plugin</artifactId>
+                        <configuration>
+                            <outputFile>/Users/nico/Developer/Spigot/Latest/plugins/${project.artifactId}.jar</outputFile>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
 
     <dependencies>
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.planetgallium</groupId>
     <artifactId>KitPvP</artifactId>
-    <version>2.2.1</version>
+    <version>2.2.2</version>
     <packaging>jar</packaging>
 
     <name>${project.artifactId}</name>
@@ -58,6 +58,8 @@
                                 <exclude>com/cryptomorin/xseries/XEntity*</exclude>
                                 <exclude>com/cryptomorin/xseries/XItemStack*</exclude>
                                 <exclude>com/cryptomorin/xseries/XBlock*</exclude>
+                                <exclude>com/cryptomorin/xseries/XTag*</exclude>
+                                <exclude>com/cryptomorin/xseries/XWorldBorder*</exclude>
                             </excludes>
                         </filter>
                     </filters>
@@ -89,7 +91,7 @@
         <dependency>
             <groupId>org.spigotmc</groupId>
             <artifactId>spigot-api</artifactId>
-            <version>1.19-R0.1-SNAPSHOT</version>
+            <version>1.20.4-R0.1-SNAPSHOT</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
@@ -113,7 +115,7 @@
         <dependency>
             <groupId>com.github.cryptomorin</groupId>
             <artifactId>XSeries</artifactId>
-            <version>9.0.0</version>
+            <version>9.9.0</version>
             <scope>compile</scope>
         </dependency>
         <dependency>

--- a/src/main/java/com/planetgallium/database/TopEntry.java
+++ b/src/main/java/com/planetgallium/database/TopEntry.java
@@ -12,10 +12,10 @@ public class TopEntry implements Comparable<TopEntry> {
 
     @Override
     public int compareTo(TopEntry otherEntry) {
-        if (otherEntry.getValue() > this.getValue()) {
-            return -1;
-        } else if (otherEntry.getValue() < this.getValue()) {
+        if (this.getValue() < otherEntry.getValue()) {
             return 1;
+        } else if (this.getValue() > otherEntry.getValue()) {
+            return -1;
         }
         return 0; // if they're equal, will return 0
     }

--- a/src/main/java/com/planetgallium/kitpvp/Game.java
+++ b/src/main/java/com/planetgallium/kitpvp/Game.java
@@ -35,7 +35,6 @@ public class Game extends JavaPlugin implements Listener {
 	
 	@Override
 	public void onEnable() {
-
 		Toolkit.printToConsole("&7[&b&lKIT-PVP&7] &7Enabling &bKitPvP &7version &b" + this.getDescription().getVersion() + "&7...");
 
 		instance = this;
@@ -90,7 +89,6 @@ public class Game extends JavaPlugin implements Listener {
 		populateUUIDCacheForOnlinePlayers();
 
 		Toolkit.printToConsole("&7[&b&lKIT-PVP&7] &aDone!");
-		
 	}
 
 	private void populateUUIDCacheForOnlinePlayers() {
@@ -126,14 +124,10 @@ public class Game extends JavaPlugin implements Listener {
 			return;
 		}
 
-		if (Toolkit.matchesConfigItem(Toolkit.getMainHandItem(p), resources.getConfig(), "Items.Leave")) {
-
+		if (Toolkit.matchesConfigItem(Toolkit.getHandItemForInteraction(e), resources.getConfig(), "Items.Leave")) {
 			if (resources.getConfig().getBoolean("Items.Leave.Enabled")) {
-
 				if (e.getAction() == Action.RIGHT_CLICK_AIR || e.getAction() == Action.RIGHT_CLICK_BLOCK) {
-
 					if (resources.getConfig().getBoolean("Items.Leave.BungeeCord.Enabled")) {
-
 						ByteArrayDataOutput out = ByteStreams.newDataOutput();
 						out.writeUTF("Connect");
 
@@ -141,17 +135,11 @@ public class Game extends JavaPlugin implements Listener {
 
 						out.writeUTF(server);
 						p.sendPluginMessage(this, "BungeeCord", out.toByteArray());
-
 					}
-
 					e.setCancelled(true);
-
 				}
-
 			}
-
 		}
-		
 	}
 
 	@Override

--- a/src/main/java/com/planetgallium/kitpvp/api/EventListener.java
+++ b/src/main/java/com/planetgallium/kitpvp/api/EventListener.java
@@ -28,23 +28,18 @@ public class EventListener implements Listener {
 		if (e.getAction() == Action.RIGHT_CLICK_AIR || e.getAction() == Action.RIGHT_CLICK_BLOCK) {
 			if (Toolkit.inArena(e.getPlayer())) {
 				Player p = e.getPlayer();
-
-				if (Toolkit.itemUsedIsOffhand(e)) {
-					return; // PlayerInteractEvent is triggered twice if there is an item in the offhand
-				}
+				ItemStack currentItem = Toolkit.getHandItemForInteraction(e);
 
 				if (resources.getConfig().getBoolean("Arena.AbilitiesRequireKit") &&
-						!arena.getKits().hasKit(p.getName())) {
+						!arena.getKits().playerHasKit(p.getName())) {
 					return; // if "AbilitiesRequireKit" true, and player does not have kit, return
 				}
-
-				ItemStack currentItem = Toolkit.getMainHandItem(p);
 
 				if (currentItem.hasItemMeta() && currentItem.getItemMeta().hasDisplayName()) {
 					Ability abilityResult = arena.getAbilities().getAbilityByActivator(currentItem);
 
 					if (abilityResult != null) {
-						Bukkit.getPluginManager().callEvent(new PlayerAbilityEvent(p, abilityResult));
+						Bukkit.getPluginManager().callEvent(new PlayerAbilityEvent(p, abilityResult, e));
 						e.setCancelled(true);
 					}
 				}

--- a/src/main/java/com/planetgallium/kitpvp/api/EventListener.java
+++ b/src/main/java/com/planetgallium/kitpvp/api/EventListener.java
@@ -29,6 +29,10 @@ public class EventListener implements Listener {
 			if (Toolkit.inArena(e.getPlayer())) {
 				Player p = e.getPlayer();
 
+				if (Toolkit.itemUsedIsOffhand(e)) {
+					return; // PlayerInteractEvent is triggered twice if there is an item in the offhand
+				}
+
 				if (resources.getConfig().getBoolean("Arena.AbilitiesRequireKit") &&
 						!arena.getKits().hasKit(p.getName())) {
 					return; // if "AbilitiesRequireKit" true, and player does not have kit, return

--- a/src/main/java/com/planetgallium/kitpvp/api/Kit.java
+++ b/src/main/java/com/planetgallium/kitpvp/api/Kit.java
@@ -20,7 +20,7 @@ public class Kit {
     private String permission;
     private Cooldown cooldown;
     private int level;
-    private int health;
+    private int maxHealth;
 
     private final Map<String, Object> options;
     private final Map<Integer, ItemStack> inventory;
@@ -35,7 +35,6 @@ public class Kit {
 
     public Kit(String name) {
         this.name = name;
-
         this.options = new HashMap<>();
         this.inventory = new HashMap<>();
         this.effects = new ArrayList<>();
@@ -53,8 +52,8 @@ public class Kit {
         this.level = level;
     }
 
-    public void setHealth(int health) {
-        this.health = health;
+    public void setMaxHealth(int health) {
+        this.maxHealth = health;
     }
 
     public void setOption(String key, Object value) {
@@ -97,7 +96,6 @@ public class Kit {
     }
 
     public void apply(Player player) {
-
         List<ItemStack> overflowItems = new ArrayList<>();
         boolean addOverflowItems = (Boolean) options.get("AddOverflowItemsOnKit");
 
@@ -133,7 +131,7 @@ public class Kit {
             }
         }
 
-        Toolkit.setMaxHealth(player, health);
+        Toolkit.setMaxHealth(player, maxHealth);
 
         for (int i = 0; i < 36; i++) {
             if (addOverflowItems) {
@@ -169,7 +167,6 @@ public class Kit {
     }
 
     private void giveOverflowItems(Player p, List<ItemStack> overflowItems) {
-
         for (int i = 0; i < 36; i++) {
             if (p.getInventory().getItem(i) == null) { // if empty slot found
                 if (overflowItems.size() >= 1) {
@@ -193,15 +190,13 @@ public class Kit {
             String overflowItemsLostMessage = (String) options.get("Message-OverflowItemsLost");
             p.sendMessage(overflowItemsLostMessage.replace("%number%", String.valueOf(overflowItems.size())));
         }
-
     }
 
     public void toResource(Resource resource) {
-
         resource.set("Kit.Permission", permission != null ? permission : "kp.kit." + name);
         resource.set("Kit.Cooldown", cooldown != null ? cooldown.formatted(true) : 0);
         resource.set("Kit.Level", level);
-        resource.set("Kit.Health", health);
+        resource.set("Kit.Health", maxHealth);
         resource.save();
 
         AttributeWriter.itemStackToResource(resource, "Inventory.Armor.Helmet", kitHelmet);
@@ -221,7 +216,6 @@ public class Kit {
         }
 
         resource.save();
-
     }
 
     public String getName() { return name; }
@@ -232,7 +226,7 @@ public class Kit {
 
     public int getLevel() { return level; }
 
-    public int getHealth() { return health; }
+    public int getMaxHealth() { return maxHealth; }
 
     public Map<Integer, ItemStack> getInventory() { return inventory; }
 

--- a/src/main/java/com/planetgallium/kitpvp/api/PlayerAbilityEvent.java
+++ b/src/main/java/com/planetgallium/kitpvp/api/PlayerAbilityEvent.java
@@ -3,6 +3,7 @@ package com.planetgallium.kitpvp.api;
 import org.bukkit.entity.Player;
 import org.bukkit.event.Event;
 import org.bukkit.event.HandlerList;
+import org.bukkit.event.player.PlayerInteractEvent;
 
 public class PlayerAbilityEvent extends Event {
 
@@ -10,10 +11,12 @@ public class PlayerAbilityEvent extends Event {
 	
 	private final Player player;
 	private final Ability ability;
+	private final PlayerInteractEvent originalInteractionEvent;
 	
-	public PlayerAbilityEvent(Player player, Ability ability) {
+	public PlayerAbilityEvent(Player player, Ability ability, PlayerInteractEvent originalInteractionEvent) {
 		this.player = player;
 		this.ability = ability;
+		this.originalInteractionEvent = originalInteractionEvent;
 	}
 	
 	public Player getPlayer() { return player; }
@@ -23,6 +26,8 @@ public class PlayerAbilityEvent extends Event {
 	public HandlerList getHandlers() { return HANDLERS; }
 
 	public String getEventName() { return "PlayerAbilityEvent"; }
+
+	public PlayerInteractEvent getOriginalInteractionEvent() { return originalInteractionEvent; }
 
 	public static HandlerList getHandlerList() { return HANDLERS; }
 	

--- a/src/main/java/com/planetgallium/kitpvp/command/MainCommand.java
+++ b/src/main/java/com/planetgallium/kitpvp/command/MainCommand.java
@@ -199,7 +199,8 @@ public class MainCommand implements CommandExecutor {
     private void executeReloadCommand(CommandSender sender) {
         resources.reload();
         CacheManager.clearCaches();
-        arena.getMenus().getKitMenu().clearCache();
+        arena.getMenus().getKitMenu().rebuildCache();
+        arena.getAbilities().rebuildCache();
 
         sender.sendMessage(messages.fetchString("Messages.Commands.Reload"));
     }

--- a/src/main/java/com/planetgallium/kitpvp/command/MainCommand.java
+++ b/src/main/java/com/planetgallium/kitpvp/command/MainCommand.java
@@ -48,52 +48,53 @@ public class MainCommand implements CommandExecutor {
 
         } else if (args.length == 1) {
 
-            if (args[0].equalsIgnoreCase("help")) {
+            if (isCommand(args, sender,"help", null)) {
                 executeHelpCommand(sender);
                 return true;
 
-            } else if (args[0].equalsIgnoreCase("reload") && hasPermission(sender, "kp.command.reload")) {
+            } else if (isCommand(args, sender, "reload", "kp.command.reload")) {
                 executeReloadCommand(sender);
                 return true;
 
-            } else if (args[0].equalsIgnoreCase("debug") && hasPermission(sender, "kp.command.debug")) {
+            } else if (isCommand(args, sender, "debug", "kp.command.debug")) {
                 executeDebugCommand(sender);
                 return true;
 
-            } else if (args[0].equalsIgnoreCase("export") && hasPermission(sender, "kp.command.export")) {
+            } else if (isCommand(args, sender, "export", "kp.command.export")) {
                 executeExportCommand(sender);
                 return true;
 
-            } else if (args[0].equalsIgnoreCase("kits") && hasPermission(sender, "kp.command.kits")) {
+            } else if (isCommand(args, sender, "kits", "kp.command.kits")) {
                 executeKitsCommand(sender);
                 return true;
+
             }
 
         } else if (args.length == 2) {
 
-            if (args[0].equalsIgnoreCase("clear") && hasPermission(sender, "kp.command.clear.other")) {
+            if (isCommand(args, sender, "clear", "kp.command.clear.other")) {
                 executeClearCommandOther(sender, args);
                 return true;
 
-            } else if (args[0].equalsIgnoreCase("delete") && hasPermission(sender, "kp.command.delete")) {
+            } else if (isCommand(args, sender, "delete", "kp.command.delete")) {
                 executeDeleteKitCommand(sender, args);
                 return true;
 
-            } else if (args[0].equalsIgnoreCase("stats") && hasPermission(sender, "kp.command.stats.other")) {
+            } else if (isCommand(args, sender, "stats", "kp.command.stats.other")) {
                 executeStatsCommandOther(sender, args);
                 return true;
             }
 
         } else if (args.length == 3) {
 
-            if (args[0].equalsIgnoreCase("kit") && hasPermission(sender, "kp.command.kit.other")) {
+            if (isCommand(args, sender, "kit", "kp.command.kit.other")) {
                 executeKitCommand(sender, args);
                 return true;
             }
 
         } else if (args.length == 4) {
 
-            if (args[0].equalsIgnoreCase("setstats") && hasPermission(sender, "kp.command.setstats")) {
+            if (isCommand(args, sender, "setstats", "kp.command.setstats")) {
                 executeSetStatsCommand(sender, args);
                 return true;
             }
@@ -105,49 +106,63 @@ public class MainCommand implements CommandExecutor {
 
             if (args.length == 1) {
 
-                if (args[0].equalsIgnoreCase("stats") && hasPermission(sender, "kp.command.stats")) {
+                if (isCommand(args, sender, "stats", "kp.command.stats")) {
                     executeStatsCommandSelf(p);
                     return true;
 
-                } else if (args[0].equalsIgnoreCase("menu") && hasPermission(sender, "kp.command.menu")) {
+                } else if (isCommand(args, sender, "menu", "kp.command.menu")) {
                     executeMenuCommand(p);
                     return true;
 
-                } else if (args[0].equalsIgnoreCase("spawn") && hasPermission(sender, "kp.command.spawn")) {
+                } else if (isCommand(args, sender, "spawn", "kp.command.spawn")) {
                     executeSpawnCommand(p);
                     return true;
 
-                } else if (args[0].equalsIgnoreCase("clear") && hasPermission(sender, "kp.command.clear")) {
+                } else if (isCommand(args, sender, "clear","kp.command.clear")) {
                     executeClearCommandSelf(p);
                     return true;
 
-                } else if (args[0].equalsIgnoreCase("addspawn") && hasPermission(p, "kp.command.addspawn")) {
+                } else if (isCommand(args, sender, "addspawn", "kp.command.addspawn")) {
                     executeAddSpawnCommand(p);
                     return true;
 
-                } else if (args[0].equalsIgnoreCase("delarena") && hasPermission(sender, "kp.command.delarena")) {
+                } else if (isCommand(args, sender, "delarena", "kp.command.delarena")) {
                     executeDeleteArenaCommand(p);
                     return true;
+
+                } else {
+                    sendUnknownCommand(sender, alias, args);
+                    return true;
+
                 }
 
             } else if (args.length == 2) {
 
-                if (args[0].equalsIgnoreCase("arena") && hasPermission(sender, "kp.command.spawn")) {
+                if (isCommand(args, sender, "arena", "kp.command.spawn")) {
                     executeArenaCommand(p, args);
                     return true;
 
-                } else if (args[0].equalsIgnoreCase("preview") && hasPermission(sender, "kp.command.preview")) {
+                } else if (isCommand(args, sender, "preview", "kp.command.preview")) {
                     executePreviewCommand(p, args);
                     return true;
 
-                } else if (args[0].equalsIgnoreCase("create") && hasPermission(sender, "kp.command.create")) {
+                } else if (isCommand(args, sender, "create", "kp.command.create")) {
                     executeCreateKitCommand(p, args);
                     return true;
 
-                } else if (args[0].equalsIgnoreCase("kit")) {
+                } else if (isCommand(args, sender, "kit", null)) {
                     executeKitCommandSelf(p, args);
                     return true;
+
+                } else {
+                    sendUnknownCommand(sender, alias, args);
+                    return true;
+
                 }
+
+            } else {
+                sendUnknownCommand(sender, alias, args);
+                return true;
 
             }
 
@@ -155,8 +170,6 @@ public class MainCommand implements CommandExecutor {
             sender.sendMessage(messages.fetchString("Messages.General.Player"));
             return true;
         }
-
-        return false;
 
     }
 
@@ -212,10 +225,17 @@ public class MainCommand implements CommandExecutor {
             names += plugin.getName() + " ";
         }
 
-        sender.sendMessage(Toolkit.translate("&7[&b&lKIT-PVP&7] &aServer Version: &7" + Bukkit.getBukkitVersion()) + " " + (Bukkit.getVersion().contains("Spigot") ? "(Spigot)" : "(Other)"));
-        sender.sendMessage(Toolkit.translate("&7[&b&lKIT-PVP&7] &aPlugin Version: &7" + plugin.getDescription().getVersion() + " " + (plugin.needsUpdate() ? "&c(Requires Update)" : "&a(Latest Version)")));
-        sender.sendMessage(Toolkit.translate("&7[&b&lKIT-PVP&7] &aSpawn Set: " + (config.contains("Arenas") ? "&aConfigured" : "&cUnconfigured")));
-        sender.sendMessage(Toolkit.translate("&7[&b&lKIT-PVP&7] &aSupport Discord: &7https://discord.gg/Hfej6UR8Bk"));
+        String serverVersion = Bukkit.getBukkitVersion() + " " +
+                (Bukkit.getVersion().contains("Spigot") ? "(Spigot)" : "(Other)");
+        String pluginVersion = plugin.getDescription().getVersion() + " " +
+                (plugin.needsUpdate() ? "&c(Requires Update)" : "&a(Latest Version)");
+        String isSpawnSet = (config.contains("Arenas") ? "&aConfigured" : "&cUnconfigured");
+        String supportDiscordLink = "https://discord.gg/Hfej6UR8Bk";
+
+        sender.sendMessage(Toolkit.translate("&7[&b&lKIT-PVP&7] &aServer Version: &7" + serverVersion));
+        sender.sendMessage(Toolkit.translate("&7[&b&lKIT-PVP&7] &aPlugin Version: &7" + pluginVersion));
+        sender.sendMessage(Toolkit.translate("&7[&b&lKIT-PVP&7] &aSpawn Set: " + isSpawnSet));
+        sender.sendMessage(Toolkit.translate("&7[&b&lKIT-PVP&7] &aSupport Discord: &7" + supportDiscordLink));
         sender.sendMessage(Toolkit.translate("&7[&b&lKIT-PVP&7] &aPlugin List: &7" + names));
     }
 
@@ -258,7 +278,8 @@ public class MainCommand implements CommandExecutor {
             clearKit(target);
 
             target.sendMessage(messages.fetchString("Messages.Commands.Cleared"));
-            sender.sendMessage(messages.fetchString("Messages.Commands.ClearedOther").replace("%player%", target.getName()));
+            sender.sendMessage(messages.fetchString("Messages.Commands.ClearedOther")
+                    .replace("%player%", target.getName()));
 
         } else {
             sender.sendMessage(messages.fetchString("Messages.Error.Offline"));
@@ -297,7 +318,9 @@ public class MainCommand implements CommandExecutor {
             Kit kitToGive = arena.getKits().getKitByName(kitName);
             arena.getKits().attemptToGiveKitToPlayer(target, kitToGive);
 
-            sender.sendMessage(messages.fetchString("Messages.Commands.KitOther").replace("%player%", playerName).replace("%kit%", kitName));
+            sender.sendMessage(messages.fetchString("Messages.Commands.KitOther")
+                    .replace("%player%", playerName)
+                    .replace("%kit%", kitName));
         } else {
             sender.sendMessage(messages.fetchString("Messages.Error.Offline"));
         }
@@ -350,7 +373,8 @@ public class MainCommand implements CommandExecutor {
 
     private void executeSpawnCommand(Player p) {
         if (!config.contains("Arenas." + p.getWorld().getName())) {
-            p.sendMessage(messages.fetchString("Messages.Error.Arena").replace("%arena%", p.getWorld().getName()));
+            p.sendMessage(messages.fetchString("Messages.Error.Arena")
+                    .replace("%arena%", p.getWorld().getName()));
             return;
         }
 
@@ -412,7 +436,8 @@ public class MainCommand implements CommandExecutor {
 
     private void executeAddSpawnCommand(Player p) {
         String arenaName = p.getWorld().getName();
-        int spawnNumber = Toolkit.getNextAvailable(config, "Arenas." + arenaName, 1000, false, 1);
+        int spawnNumber = Toolkit.getNextAvailable(config, "Arenas." + arenaName,
+                1000, false, 1);
 
         Toolkit.saveLocationToResource(config, "Arenas." + arenaName + "." + spawnNumber, p.getLocation());
 
@@ -440,7 +465,7 @@ public class MainCommand implements CommandExecutor {
         String arenaName = args[1];
 
         if (resources.getConfig().getBoolean("Arena.PreventArenaSignUseWithKit")) {
-            if (arena.getKits().hasKit(p.getName())) {
+            if (arena.getKits().playerHasKit(p.getName())) {
                 p.sendMessage(messages.fetchString("Messages.Error.KitInvalid"));
                 return;
             }
@@ -494,7 +519,8 @@ public class MainCommand implements CommandExecutor {
             return true;
         }
 
-        sender.sendMessage(messages.fetchString("Messages.General.Permission").replace("%permission%", permission));
+        sender.sendMessage(messages.fetchString("Messages.General.Permission")
+                .replace("%permission%", permission));
         return false;
     }
 
@@ -513,7 +539,7 @@ public class MainCommand implements CommandExecutor {
             arena.giveArenaItems(p);
         }
 
-        arena.getKits().resetKit(p.getName());
+        arena.getKits().resetPlayerKit(p.getName());
     }
 
     private void sendStatsMessage(CommandSender receiver, String username) {
@@ -523,10 +549,23 @@ public class MainCommand implements CommandExecutor {
     }
 
     private boolean validateKitName(String possibleKitName) {
-        if (possibleKitName.contains("-") || possibleKitName.contains("+")) {
-            return false;
+        return !possibleKitName.contains("-") && !possibleKitName.contains("+");
+    }
+
+    private boolean isCommand(String[] args, CommandSender sender, String arg0, String permission) {
+        if (args[0].equalsIgnoreCase(arg0)) {
+            return permission == null || hasPermission(sender, permission);
         }
-        return true;
+        return false;
+    }
+
+    private void sendUnknownCommand(CommandSender sender, String alias, String[] args) {
+        StringBuilder unknownCommand = new StringBuilder();
+        for (String arg : args) {
+            unknownCommand.append(arg).append(" ");
+        }
+
+        sender.sendMessage(Toolkit.translate("%prefix% &cUnknown command: /" + alias + " " + unknownCommand));
     }
 
 }

--- a/src/main/java/com/planetgallium/kitpvp/command/MainCommand.java
+++ b/src/main/java/com/planetgallium/kitpvp/command/MainCommand.java
@@ -17,7 +17,6 @@ import org.bukkit.plugin.Plugin;
 import org.bukkit.potion.PotionEffect;
 import org.bukkit.scheduler.BukkitRunnable;
 
-import java.io.File;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -58,10 +57,6 @@ public class MainCommand implements CommandExecutor {
 
             } else if (isCommand(args, sender, "debug", "kp.command.debug")) {
                 executeDebugCommand(sender);
-                return true;
-
-            } else if (isCommand(args, sender, "export", "kp.command.export")) {
-                executeExportCommand(sender);
                 return true;
 
             } else if (isCommand(args, sender, "kits", "kp.command.kits")) {
@@ -204,7 +199,6 @@ public class MainCommand implements CommandExecutor {
         sender.sendMessage(Toolkit.translate("&7- &b/kp stats <player> &7View the stats of another player."));
         sender.sendMessage(Toolkit.translate("&7- &b/kp menu &7Displays the kits menu."));
         sender.sendMessage(Toolkit.translate("&7- &b/kp setstats <player> <type> <amount> &7Change stats of a player."));
-        sender.sendMessage(Toolkit.translate("&7- &b/kp export &7Exports all stats to the new storage format."));
         sender.sendMessage(Toolkit.translate(" "));
         sender.sendMessage(Toolkit.translate("&3&m                                                                               "));
     }
@@ -237,23 +231,6 @@ public class MainCommand implements CommandExecutor {
         sender.sendMessage(Toolkit.translate("&7[&b&lKIT-PVP&7] &aSpawn Set: " + isSpawnSet));
         sender.sendMessage(Toolkit.translate("&7[&b&lKIT-PVP&7] &aSupport Discord: &7" + supportDiscordLink));
         sender.sendMessage(Toolkit.translate("&7[&b&lKIT-PVP&7] &aPlugin List: &7" + names));
-    }
-
-    private void executeExportCommand(CommandSender sender) {
-        File statsFile = new File(plugin.getDataFolder().getAbsolutePath() + "/stats.yml");
-
-        if (statsFile.exists()) {
-            sender.sendMessage(Toolkit.translate("%prefix% &7Exporting data, this may take a while..."));
-            new BukkitRunnable() {
-                @Override
-                public void run() {
-                    plugin.getDatabase().exportStats();
-                }
-            }.runTaskAsynchronously(plugin);
-            sender.sendMessage(Toolkit.translate("%prefix% &aStats successfully exported to database."));
-        } else {
-            sender.sendMessage(Toolkit.translate("%prefix% &cNo stats.yml was found to export from."));
-        }
     }
 
     private void executeKitsCommand(CommandSender sender) {
@@ -316,11 +293,11 @@ public class MainCommand implements CommandExecutor {
 
         if (target != null && Toolkit.inArena(target)) {
             Kit kitToGive = arena.getKits().getKitByName(kitName);
-            arena.getKits().attemptToGiveKitToPlayer(target, kitToGive);
-
             sender.sendMessage(messages.fetchString("Messages.Commands.KitOther")
                     .replace("%player%", playerName)
                     .replace("%kit%", kitName));
+
+            arena.getKits().attemptToGiveKitToPlayer(target, kitToGive);
         } else {
             sender.sendMessage(messages.fetchString("Messages.Error.Offline"));
         }

--- a/src/main/java/com/planetgallium/kitpvp/command/MainCommand.java
+++ b/src/main/java/com/planetgallium/kitpvp/command/MainCommand.java
@@ -351,6 +351,7 @@ public class MainCommand implements CommandExecutor {
     private void executeSpawnCommand(Player p) {
         if (!config.contains("Arenas." + p.getWorld().getName())) {
             p.sendMessage(messages.fetchString("Messages.Error.Arena").replace("%arena%", p.getWorld().getName()));
+            return;
         }
 
         if (spawnUsers.contains(p.getName())) {

--- a/src/main/java/com/planetgallium/kitpvp/command/MainCommand.java
+++ b/src/main/java/com/planetgallium/kitpvp/command/MainCommand.java
@@ -78,6 +78,7 @@ public class MainCommand implements CommandExecutor {
             } else if (isCommand(args, sender, "stats", "kp.command.stats.other")) {
                 executeStatsCommandOther(sender, args);
                 return true;
+
             }
 
         } else if (args.length == 3) {
@@ -308,10 +309,7 @@ public class MainCommand implements CommandExecutor {
         String statsIdentifier = args[2];
         String possibleAmount = args[3];
 
-        if (statsIdentifier.equalsIgnoreCase("kills") ||
-                statsIdentifier.equalsIgnoreCase("deaths") ||
-                statsIdentifier.equalsIgnoreCase("level") ||
-                statsIdentifier.equalsIgnoreCase("experience")) {
+        if (isValidStatIdentifier(statsIdentifier, true)) {
 
             if (!StringUtils.isNumeric(possibleAmount)) {
                 sender.sendMessage(resources.getMessages().fetchString("Messages.Error.InvalidNumber")
@@ -361,7 +359,7 @@ public class MainCommand implements CommandExecutor {
 
         p.sendMessage(messages.fetchString("Messages.Commands.Teleporting"));
         spawnUsers.add(p.getName());
-        XSound.play(p, "ENTITY_ITEM_PICKUP, 1, -1");
+        Toolkit.playSoundToPlayer(p, "ENTITY_ITEM_PICKUP", -1);
 
         Location beforeLocation = p.getLocation();
 
@@ -376,7 +374,7 @@ public class MainCommand implements CommandExecutor {
                     if (p.getGameMode() != GameMode.SPECTATOR) {
                         p.sendMessage(messages.fetchString("Messages.Commands.Time")
                                 .replace("%time%", String.valueOf(time)));
-                        XSound.play(p, "BLOCK_NOTE_BLOCK_SNARE, 1, 1");
+                        Toolkit.playSoundToPlayer(p, "BLOCK_NOTE_BLOCK_SNARE", 1);
 
                         if (beforeLocation.getBlockX() != p.getLocation().getBlockX() ||
                                 beforeLocation.getBlockY() != p.getLocation().getBlockY() ||
@@ -399,7 +397,7 @@ public class MainCommand implements CommandExecutor {
                     }
 
                     spawnUsers.remove(p.getName());
-                    XSound.play(p, "ENTITY_ENDERMAN_TELEPORT, 1, 1");
+                    Toolkit.playSoundToPlayer(p, "ENTITY_ENDERMAN_TELEPORT", 1);
                     cancel();
                 }
             }
@@ -421,7 +419,7 @@ public class MainCommand implements CommandExecutor {
         p.sendMessage(messages.fetchString("Messages.Commands.Added")
                 .replace("%number%", String.valueOf(spawnNumber))
                 .replace("%arena%", arenaName));
-        XSound.play(p, "ENTITY_ZOMBIE_ATTACK_WOODEN_DOOR, 1, 1");
+        Toolkit.playSoundToPlayer(p, "ENTITY_ZOMBIE_ATTACK_WOODEN_DOOR", 1);
     }
 
     private void executeDeleteArenaCommand(Player p) {
@@ -432,7 +430,7 @@ public class MainCommand implements CommandExecutor {
             plugin.saveConfig();
 
             p.sendMessage(messages.fetchString("Messages.Commands.Removed").replace("%arena%", arenaName));
-            XSound.play(p, "ENTITY_ZOMBIE_ATTACK_WOODEN_DOOR, 1, 1");
+            Toolkit.playSoundToPlayer(p, "ENTITY_ZOMBIE_ATTACK_WOODEN_DOOR", 1);
         } else {
             p.sendMessage(messages.fetchString("Messages.Error.Arena"));
         }
@@ -502,6 +500,8 @@ public class MainCommand implements CommandExecutor {
     }
 
     private void clearKit(Player p) {
+        CacheManager.getPotionSwitcherUsers().remove(p.getName());
+
         p.getInventory().setArmorContents(null);
         p.getInventory().clear();
 
@@ -543,6 +543,13 @@ public class MainCommand implements CommandExecutor {
         }
 
         sender.sendMessage(Toolkit.translate("%prefix% &cUnknown command: /" + alias + " " + unknownCommand));
+    }
+
+    private boolean isValidStatIdentifier(String identifierToValidate, boolean includeExperience) {
+        return (identifierToValidate.equalsIgnoreCase("kills") ||
+                identifierToValidate.equalsIgnoreCase("deaths") ||
+                identifierToValidate.equalsIgnoreCase("level")) ||
+                (includeExperience && identifierToValidate.equalsIgnoreCase("experience"));
     }
 
 }

--- a/src/main/java/com/planetgallium/kitpvp/game/Abilities.java
+++ b/src/main/java/com/planetgallium/kitpvp/game/Abilities.java
@@ -35,9 +35,14 @@ public class Abilities {
     }
 
     public Ability getAbilityByActivator(ItemStack potentialActivator) {
+        int previousPotentialActivatorAmount = potentialActivator.getAmount();
+        potentialActivator.setAmount(1);
+
         for (ItemStack loadedActivator : activatorToAbility.keySet()) {
             if (Toolkit.itemStacksMatch(loadedActivator, potentialActivator)) {
-                return activatorToAbility.get(potentialActivator);
+                Ability ability = activatorToAbility.get(potentialActivator);
+                potentialActivator.setAmount(previousPotentialActivatorAmount);
+                return ability;
             }
         }
         return null;

--- a/src/main/java/com/planetgallium/kitpvp/game/Abilities.java
+++ b/src/main/java/com/planetgallium/kitpvp/game/Abilities.java
@@ -17,13 +17,17 @@ import java.util.Map;
 
 public class Abilities {
 
+    private final Resources resources;
     private final Map<ItemStack, Ability> activatorToAbility;
 
     public Abilities(Game plugin) {
-        Resources resources = plugin.getResources();
-
+        this.resources = plugin.getResources();
         this.activatorToAbility = new HashMap<>();
 
+        rebuildCache();
+    }
+
+    public void rebuildCache() {
         for (Resource abilityResource : resources.getAbilityResources()) {
             Ability ability = getAbilityFromResource(abilityResource);
             activatorToAbility.put(ability.getActivator(), ability);

--- a/src/main/java/com/planetgallium/kitpvp/game/Abilities.java
+++ b/src/main/java/com/planetgallium/kitpvp/game/Abilities.java
@@ -18,11 +18,11 @@ import java.util.Map;
 public class Abilities {
 
     private final Resources resources;
-    private final Map<ItemStack, Ability> activatorToAbility;
+    private final Map<AbilityActivatorMetaData, Ability> activatorDataToAbility;
 
     public Abilities(Game plugin) {
         this.resources = plugin.getResources();
-        this.activatorToAbility = new HashMap<>();
+        this.activatorDataToAbility = new HashMap<>();
 
         rebuildCache();
     }
@@ -30,22 +30,13 @@ public class Abilities {
     public void rebuildCache() {
         for (Resource abilityResource : resources.getAbilityResources()) {
             Ability ability = getAbilityFromResource(abilityResource);
-            activatorToAbility.put(ability.getActivator(), ability);
+            AbilityActivatorMetaData activatorMetaData = new AbilityActivatorMetaData(ability.getActivator());
+            activatorDataToAbility.put(activatorMetaData, ability);
         }
     }
 
     public Ability getAbilityByActivator(ItemStack potentialActivator) {
-        int previousPotentialActivatorAmount = potentialActivator.getAmount();
-        potentialActivator.setAmount(1);
-
-        for (ItemStack loadedActivator : activatorToAbility.keySet()) {
-            if (Toolkit.itemStacksMatch(loadedActivator, potentialActivator)) {
-                Ability ability = activatorToAbility.get(potentialActivator);
-                potentialActivator.setAmount(previousPotentialActivatorAmount);
-                return ability;
-            }
-        }
-        return null;
+        return activatorDataToAbility.get(new AbilityActivatorMetaData(potentialActivator));
     }
 
     private Ability getAbilityFromResource(Resource resource) {
@@ -101,6 +92,42 @@ public class Abilities {
         }
 
         return ability;
+    }
+
+    public class AbilityActivatorMetaData {
+
+        private final String materialName;
+        private String displayName;
+
+        public AbilityActivatorMetaData(ItemStack buildFromItem) {
+            this.materialName = buildFromItem.getType().toString();
+            if (buildFromItem.hasItemMeta()) {
+                ItemMeta itemMeta = buildFromItem.getItemMeta();
+                if (itemMeta.hasDisplayName()) {
+                    this.displayName = itemMeta.getDisplayName();
+                }
+            }
+        }
+
+        @Override
+        public boolean equals(Object otherObject) {
+            if (otherObject instanceof AbilityActivatorMetaData) {
+                AbilityActivatorMetaData otherAbilityData = (AbilityActivatorMetaData) otherObject;
+                return this.displayName.equals(otherAbilityData.getDisplayName()) &&
+                        this.materialName.equals(otherAbilityData.getMaterialName());
+            }
+            return false;
+        }
+
+        @Override
+        public int hashCode() {
+            return this.displayName.hashCode() + this.materialName.hashCode();
+        }
+
+        public String getDisplayName() { return displayName; }
+
+        public String getMaterialName() { return materialName; }
+
     }
 
 }

--- a/src/main/java/com/planetgallium/kitpvp/game/Arena.java
+++ b/src/main/java/com/planetgallium/kitpvp/game/Arena.java
@@ -72,10 +72,14 @@ public class Arena {
 		}
 
 		p.setGameMode(GameMode.SURVIVAL);
-		Toolkit.setMaxHealth(p, 20);
+
+		if (config.getBoolean("Arena.ResetMaxHealthOnDeath")) {
+			Toolkit.setMaxHealth(p, 20);
+		}
 
 		if (config.getBoolean("Arena.FancyDeath")) {
-			p.setHealth(20.0);
+//			p.setHealth(20.0);
+			p.setHealth(Toolkit.getMaxHealth(p));
 		}
 		
 		p.setExp(0f);
@@ -96,6 +100,7 @@ public class Arena {
 	
 	public void removePlayer(Player p) {
 		CacheManager.getPlayerAbilityCooldowns(p.getName()).clear();
+		CacheManager.getPotionSwitcherUsers().remove(p.getName());
 
 		for (PotionEffect effect : p.getActivePotionEffects()) {
 			p.removePotionEffect(effect.getType());

--- a/src/main/java/com/planetgallium/kitpvp/game/Arena.java
+++ b/src/main/java/com/planetgallium/kitpvp/game/Arena.java
@@ -55,7 +55,7 @@ public class Arena {
 	public void addPlayer(Player p, boolean toSpawn, boolean giveItems) {
 		cooldowns.clearPlayerAbilityCooldowns(p.getName());
 
-		kits.resetKit(p.getName());
+		kits.resetPlayerKit(p.getName());
 
 		if (config.getBoolean("Arena.ResetKillStreakOnLeave")) {
 			killstreaks.setStreak(p, 0);
@@ -101,15 +101,11 @@ public class Arena {
 			p.removePotionEffect(effect.getType());
 		}
 		
-		kits.resetKit(p.getName());
+		kits.resetPlayerKit(p.getName());
 
 		if (config.getBoolean("Arena.ResetKillStreakOnLeave")) {
 			getKillStreaks().resetStreak(p);
 		}
-		
-//		if (config.getBoolean("Arena.FancyDeath")) {
-//			p.setHealth(20.0); commenting this out fixes block glitching for some reason
-//		}
 		
 		p.setExp(0f);
 		p.setFoodLevel(20);

--- a/src/main/java/com/planetgallium/kitpvp/game/Arena.java
+++ b/src/main/java/com/planetgallium/kitpvp/game/Arena.java
@@ -53,12 +53,11 @@ public class Arena {
 	}
 	
 	public void addPlayer(Player p, boolean toSpawn, boolean giveItems) {
-		CacheManager.getPlayerAbilityCooldowns(p.getName()).clear();
+		cooldowns.clearPlayerAbilityCooldowns(p.getName());
 
 		kits.resetKit(p.getName());
 
 		if (config.getBoolean("Arena.ResetKillStreakOnLeave")) {
-
 			killstreaks.setStreak(p, 0);
 		}
 		

--- a/src/main/java/com/planetgallium/kitpvp/game/Cooldowns.java
+++ b/src/main/java/com/planetgallium/kitpvp/game/Cooldowns.java
@@ -7,6 +7,8 @@ import com.planetgallium.kitpvp.util.CacheManager;
 import com.planetgallium.kitpvp.util.Cooldown;
 import org.bukkit.entity.Player;
 
+import java.util.Map;
+
 public class Cooldowns {
 
 	private final Stats stats;
@@ -19,6 +21,10 @@ public class Cooldowns {
 
 	public void setAbilityCooldown(String playerName, String abilityName) {
 		CacheManager.getPlayerAbilityCooldowns(playerName).put(abilityName, (System.currentTimeMillis() / 1000));
+	}
+
+	public void clearPlayerAbilityCooldowns(String playerName) {
+		CacheManager.getPlayerAbilityCooldowns(playerName).clear();
 	}
 
 	public void setKitCooldown(String username, String kitName) {

--- a/src/main/java/com/planetgallium/kitpvp/game/Infoboard.java
+++ b/src/main/java/com/planetgallium/kitpvp/game/Infoboard.java
@@ -22,7 +22,6 @@ public class Infoboard {
     private int lastSentCount;
 
     public Infoboard(final Scoreboard scoreboard2, final String title) {
-    	
         this.list = new ArrayList<ScoreboardText>();
         this.tag = "PlaceHolder";
         this.lastSentCount = -1;
@@ -30,11 +29,9 @@ public class Infoboard {
         this.tag = ChatColor.translateAlternateColorCodes('&', title);
         this.scoreBoard = scoreboard2;
         (this.objective = this.getOrCreateObjective(this.tag)).setDisplaySlot(DisplaySlot.SIDEBAR);
-        
     }
 
     public void add(String input) {
-    	
         input = ChatColor.translateAlternateColorCodes('&', input);
         
         ScoreboardText text = null;
@@ -127,11 +124,8 @@ public class Infoboard {
     /**
      * Added for testing purposes, not part of original class
      */
-    
     public void hide() {
-    	
     	objective.setDisplaySlot(null);
-    	
     }
     
 }

--- a/src/main/java/com/planetgallium/kitpvp/game/Infoboard.java
+++ b/src/main/java/com/planetgallium/kitpvp/game/Infoboard.java
@@ -3,6 +3,7 @@ package com.planetgallium.kitpvp.game;
 import java.util.ArrayList;
 import java.util.List;
 
+import com.planetgallium.kitpvp.util.Toolkit;
 import org.apache.commons.lang.StringUtils;
 import org.bukkit.ChatColor;
 import org.bukkit.entity.Player;
@@ -25,7 +26,11 @@ public class Infoboard {
         this.list = new ArrayList<ScoreboardText>();
         this.tag = "PlaceHolder";
         this.lastSentCount = -1;
-        Preconditions.checkState(title.length() <= 32, (Object) "title can not be more than 32");
+        if (title.length() > 32) {
+            Toolkit.printToConsole("&7[&b&lKIT-PVP&7] &cScoreboard title in scoreboard.yml is too long;" +
+                    " must be less than or equal to 32 characters. Scoreboard will not display.");
+        }
+        Preconditions.checkState(title.length() <= 32, (Object) "title cannot be more than 32 characters");
         this.tag = ChatColor.translateAlternateColorCodes('&', title);
         this.scoreBoard = scoreboard2;
         (this.objective = this.getOrCreateObjective(this.tag)).setDisplaySlot(DisplaySlot.SIDEBAR);

--- a/src/main/java/com/planetgallium/kitpvp/game/Kits.java
+++ b/src/main/java/com/planetgallium/kitpvp/game/Kits.java
@@ -37,6 +37,9 @@ public class Kits {
         this.kits = new HashMap<>();
     }
 
+    // Could also load and cache kits onEnable like Abilities.yml so no lag spike for hefty kit when first used by
+    // player
+
     public void createKit(Player fromPlayer, String kitName) {
 
         Kit kitToCreate = createKitFromPlayer(fromPlayer, kitName);
@@ -70,7 +73,7 @@ public class Kits {
                 menuConfig.save();
 
                 menuConfig.load();
-                arena.getMenus().getKitMenu().clearCache();
+                arena.getMenus().getKitMenu().rebuildCache();
             } else {
                 fromPlayer.sendMessage(messages.fetchString("Messages.Error.Menu"));
             }

--- a/src/main/java/com/planetgallium/kitpvp/game/Stats.java
+++ b/src/main/java/com/planetgallium/kitpvp/game/Stats.java
@@ -90,7 +90,7 @@ public class Stats {
 
             p.sendMessage(resources.getMessages().fetchString("Messages.Other.Level")
                                   .replace("%level%", String.valueOf(newLevel)));
-            XSound.play(p, "ENTITY_PLAYER_LEVELUP, 1, 1");
+            Toolkit.playSoundToPlayer(p, "ENTITY_PLAYER_LEVELUP", 1);
 
         } else {
             setStat("experience", username, 0);

--- a/src/main/java/com/planetgallium/kitpvp/game/Utilities.java
+++ b/src/main/java/com/planetgallium/kitpvp/game/Utilities.java
@@ -34,7 +34,6 @@ public class Utilities {
     }
 
     public String replaceBuiltInPlaceholdersIfPresent(String s, String username) {
-
         // The reason I'm doing all these if statements rather than a more concise code solution is to reduce
         // the amount of data that is unnecessarily fetched (ex by using .replace) to improve performance
         // no longer constantly fetching stats from database for EACH line of scoreboard on update and player join

--- a/src/main/java/com/planetgallium/kitpvp/item/AttributeParser.java
+++ b/src/main/java/com/planetgallium/kitpvp/item/AttributeParser.java
@@ -3,13 +3,11 @@ package com.planetgallium.kitpvp.item;
 import com.cryptomorin.xseries.XEnchantment;
 import com.cryptomorin.xseries.XMaterial;
 import com.cryptomorin.xseries.XPotion;
-import com.cryptomorin.xseries.XSound;
 import com.planetgallium.kitpvp.Game;
-import com.planetgallium.kitpvp.api.Ability;
-import com.planetgallium.kitpvp.util.*;
+import com.planetgallium.kitpvp.util.Resource;
+import com.planetgallium.kitpvp.util.Toolkit;
 import org.bukkit.Color;
 import org.bukkit.Material;
-import org.bukkit.Sound;
 import org.bukkit.configuration.ConfigurationSection;
 import org.bukkit.enchantments.Enchantment;
 import org.bukkit.inventory.ItemStack;
@@ -56,8 +54,8 @@ public class AttributeParser {
 
     }
 
-    public static ItemStack getItemStackFromPath(Resource resource, String path) throws IllegalAccessException, NoSuchMethodException, InvocationTargetException {
-
+    public static ItemStack getItemStackFromPath(Resource resource, String path) throws IllegalAccessException,
+            NoSuchMethodException, InvocationTargetException {
         if (!resource.contains(path)) return null;
 
         ItemStack item = XMaterial.matchXMaterial(FALLBACK_ITEM_MATERIAL).parseItem();
@@ -137,60 +135,45 @@ public class AttributeParser {
         }
 
         return item;
-
     }
 
     private static void setCustomDurability(ItemStack item, int damageAmount) {
-
         if (Toolkit.versionToNumber() < 113) {
-
             item.setDurability((short) damageAmount);
 
         } else if (Toolkit.versionToNumber() >= 113) {
-
             ItemMeta meta = item.getItemMeta();
 
             if (meta instanceof Damageable) {
-
                 ((Damageable) meta).setDamage(damageAmount);
                 item.setItemMeta(meta);
-
             }
-
         }
-
     }
 
     private static void setSkull(ItemStack item, String skullOwner) {
-
         item.setType(XMaterial.PLAYER_HEAD.parseMaterial());
 
         SkullMeta skullMeta = (SkullMeta) item.getItemMeta();
         skullMeta.setOwner(skullOwner);
 
         item.setItemMeta(skullMeta);
-
     }
 
     private static void dyeItem(ItemStack item, Color color) {
-
-        if (item.getType() == XMaterial.LEATHER_HELMET.parseMaterial() ||
-                item.getType() == XMaterial.LEATHER_CHESTPLATE.parseMaterial() ||
-                item.getType() == XMaterial.LEATHER_LEGGINGS.parseMaterial() ||
-                item.getType() == XMaterial.LEATHER_BOOTS.parseMaterial()) {
+        if (Toolkit.hasMatchingMaterial(item, "LEATHER_HELMET") ||
+                Toolkit.hasMatchingMaterial(item, "LEATHER_CHESTPLATE") ||
+                Toolkit.hasMatchingMaterial(item, "LEATHER_LEGGINGS") ||
+                Toolkit.hasMatchingMaterial(item, "LEATHER_BOOTS")) {
 
             LeatherArmorMeta dyedMeta = (LeatherArmorMeta) item.getItemMeta();
             dyedMeta.setColor(color);
             item.setItemMeta(dyedMeta);
-
         }
-
     }
 
     private static void setUnbreakable(ItemStack item) throws InvocationTargetException, IllegalAccessException, NoSuchMethodException {
-
         if (Toolkit.versionToNumber() <= 114) {
-
             ItemMeta meta = item.getItemMeta();
 
             Method spigotMethod = meta.getClass().getMethod("spigot");
@@ -203,17 +186,12 @@ public class AttributeParser {
             setUnbreakableMethod.setAccessible(true);
 
             setUnbreakableMethod.invoke(spigotInstance, true);
-
         } else if (Toolkit.versionToNumber() > 114) {
-
             item.getItemMeta().setUnbreakable(true);
-
         }
-
     }
 
     private static ItemStack setEffectsFromPath(ItemStack item, Resource resource, String path) {
-
         String effectsPath = path + ".Effects";
         String firstChildEffectName = resource.getConfigurationSection(effectsPath).getKeys(false).toArray()[0].toString();
         String firstChildPath = path + ".Effects." + firstChildEffectName;
@@ -230,11 +208,9 @@ public class AttributeParser {
         }
 
         return item;
-
     }
 
     private static ItemStack setVanillaEffectsFromPath(ItemStack item, Resource resource, String path) {
-
         PotionMeta potionMeta = (PotionMeta) item.getItemMeta();
 
         String firstChildEffectName = resource.getConfigurationSection(path).getKeys(false).toArray()[0].toString();
@@ -260,11 +236,9 @@ public class AttributeParser {
         item.setItemMeta(potionMeta);
 
         return item;
-
     }
 
     private static void setCustomEffectsFromPath(ItemStack item, Resource resource, String path) {
-
         PotionMeta potionMeta = (PotionMeta) item.getItemMeta();
 
         for (String effectName : resource.getConfigurationSection(path).getKeys(false)) {
@@ -275,11 +249,9 @@ public class AttributeParser {
         }
 
         item.setItemMeta(potionMeta);
-
     }
 
     private static int getVanillaLevel(PotionType type, boolean isUpgraded) {
-
         switch (type) {
             case INVISIBILITY: case FIRE_RESISTANCE: case NIGHT_VISION:
                 case SLOWNESS: case WATER_BREATHING: case WEAKNESS:
@@ -288,9 +260,7 @@ public class AttributeParser {
                 case REGEN: case SPEED: case STRENGTH:
                 return isUpgraded ? 2 : 1;
         }
-
         return 1;
-
     }
 
 }

--- a/src/main/java/com/planetgallium/kitpvp/item/AttributeWriter.java
+++ b/src/main/java/com/planetgallium/kitpvp/item/AttributeWriter.java
@@ -15,7 +15,6 @@ public class AttributeWriter {
     // look into using XItemStack by Crypto
 
     public static void potionEffectToResource(Resource resource, String path, PotionEffect effect) {
-
         if (effect == null) return;
 
         int amplifierNonZeroBased = effect.getAmplifier() + 1;
@@ -24,11 +23,9 @@ public class AttributeWriter {
         resource.set(path + "." + effect.getType().getName() + ".Amplifier", amplifierNonZeroBased);
         resource.set(path + "." + effect.getType().getName() + ".Duration", durationSeconds);
         resource.save();
-
     }
 
     public static void itemStackToResource(Resource resource, String path, ItemStack item) {
-
         if (item == null || item.getType() == XMaterial.AIR.parseMaterial()) return;
 
         ItemMeta meta = item.getItemMeta();
@@ -45,11 +42,9 @@ public class AttributeWriter {
         serializePotion(resource, item, path);
         serializeEnchantments(resource, item, path);
         serializeDurability(resource, item, path);
-
     }
 
     private static void serializeDyedArmor(Resource resource, ItemStack item, String path) {
-
         if (item.getType() == XMaterial.LEATHER_HELMET.parseMaterial() ||
             item.getType() == XMaterial.LEATHER_CHESTPLATE.parseMaterial() ||
             item.getType() == XMaterial.LEATHER_LEGGINGS.parseMaterial() ||
@@ -61,41 +56,29 @@ public class AttributeWriter {
             resource.set(path + ".Dye.Green", dyedMeta.getColor().getGreen());
             resource.set(path + ".Dye.Blue", dyedMeta.getColor().getBlue());
             resource.save();
-
         }
-
     }
 
     private static void serializeSkull(Resource resource, ItemStack item, String path) {
-
         if (item.getType() == XMaterial.PLAYER_HEAD.parseMaterial()) {
-
             SkullMeta skullMeta = (SkullMeta) item.getItemMeta();
 
             resource.set(path + ".Skull", skullMeta.getOwner());
             resource.save();
-
         }
-
     }
 
     private static void serializeTippedArrows(Resource resource, ItemStack item, String path) {
-
         if (Toolkit.versionToNumber() >= 19 && item.getType() == XMaterial.TIPPED_ARROW.parseMaterial()) {
-
             serializeEffects(resource, item, path);
-
         }
-
     }
 
     private static void serializeEffects(Resource resource, ItemStack item, String path) {
-
         PotionMeta meta = (PotionMeta) item.getItemMeta();
         String effectPath = path + ".Effects";
 
         if (meta.getCustomEffects().size() > 0) {
-
             for (PotionEffect effect : meta.getCustomEffects()) {
                 resource.set(effectPath + "." + effect.getType().getName() + ".Amplifier", effect.getAmplifier() + 1);
                 resource.set(effectPath + "." + effect.getType().getName() + ".Duration", effect.getDuration() / 20);
@@ -105,7 +88,6 @@ public class AttributeWriter {
         } else {
 
             if (Toolkit.versionToNumber() == 18) {
-
                 Potion potionStack = Potion.fromItemStack(item);
 
                 resource.set(path + ".Type", potionStack.isSplash() ? "SPLASH_POTION" : "POTION");
@@ -116,54 +98,39 @@ public class AttributeWriter {
                 resource.save();
 
             } else if (Toolkit.versionToNumber() >= 19) {
-
                 PotionData data = meta.getBasePotionData();
 
                 String effectName = data.getType().getEffectType().getName();
-//            resource.set(path + ".Type", data.getType().toString());
                 resource.set(effectPath + "." + effectName + ".Upgraded", data.isUpgraded());
                 resource.set(effectPath + "." + effectName + ".Extended", data.isExtended());
                 resource.save();
-
             }
-
         }
-
     }
 
     private static void serializePotion(Resource resource, ItemStack item, String path) {
-
         if (item.getType() == XMaterial.POTION.parseMaterial() ||
                 (Toolkit.versionToNumber() >= 19 &&
                         (item.getType() == XMaterial.SPLASH_POTION.parseMaterial() ||
                         item.getType() == XMaterial.LINGERING_POTION.parseMaterial()))) {
-
             serializeEffects(resource, item, path);
-
         }
-
     }
 
     private static void serializeEnchantments(Resource resource, ItemStack item, String path) {
-
         if (item.getEnchantments().size() > 0) {
-
             for (Enchantment enchantment : item.getEnchantments().keySet()) {
-
-                String enchantmentName = Toolkit.versionToNumber() < 113 ? enchantment.getName() : enchantment.getKey().getKey();
-                resource.set(path + ".Enchantments." + enchantmentName.toUpperCase(), item.getEnchantments().get(enchantment));
+                String enchantmentName = Toolkit.versionToNumber() < 113 ?
+                        enchantment.getName() : enchantment.getKey().getKey();
+                resource.set(path + ".Enchantments." + enchantmentName.toUpperCase(),
+                        item.getEnchantments().get(enchantment));
                 resource.save();
-
             }
-
         }
-
     }
 
     private static void serializeDurability(Resource resource, ItemStack item, String path) {
-
         if (Toolkit.versionToNumber() < 113) {
-
             if (item.getDurability() > 0 &&
                     item.getType() != XMaterial.PLAYER_HEAD.parseMaterial() &&
                     item.getType() != XMaterial.POTION.parseMaterial() &&
@@ -171,7 +138,6 @@ public class AttributeWriter {
 
                 resource.set(path + ".Durability", item.getDurability());
                 resource.save();
-
             }
 
         } else if (Toolkit.versionToNumber() >= 113) {
@@ -184,16 +150,11 @@ public class AttributeWriter {
                 Damageable damagedMeta = (Damageable) item.getItemMeta();
 
                 if (damagedMeta.hasDamage()) {
-
                     resource.set(path + ".Durability", damagedMeta.getDamage());
                     resource.save();
-
                 }
-
             }
-
         }
-
     }
 
 }

--- a/src/main/java/com/planetgallium/kitpvp/listener/AbilityListener.java
+++ b/src/main/java/com/planetgallium/kitpvp/listener/AbilityListener.java
@@ -2,7 +2,6 @@ package com.planetgallium.kitpvp.listener;
 
 import com.planetgallium.kitpvp.Game;
 import com.planetgallium.kitpvp.api.Ability;
-import com.planetgallium.kitpvp.api.Kit;
 import com.planetgallium.kitpvp.util.Cooldown;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
@@ -54,23 +53,17 @@ public class AbilityListener implements Listener {
 			p.playSound(p.getLocation(), ability.getSound(), ability.getSoundVolume(), ability.getSoundPitch());
 
 		if (ability.getEffects().size() > 0)
-			ability.getEffects().stream().forEach(effect -> p.addPotionEffect(effect));
+			ability.getEffects().forEach(p::addPotionEffect);
 
 		if (ability.getCommands().size() > 0)
 			Toolkit.runCommands(p, ability.getCommands(), "none", "none");
 
 		if (ability.getCooldown() == null) {
-			if (Toolkit.getMainHandItem(p).getAmount() == 1) {
-				ItemStack emptyItem = Toolkit.getMainHandItem(p);
-				emptyItem.setAmount(0);
-				Toolkit.setMainHandItem(p, emptyItem);
-			} else {
-				Toolkit.getMainHandItem(p).setAmount(Toolkit.getMainHandItem(p).getAmount() - 1);
-			}
+			ItemStack abilityItem = Toolkit.getHandItemForInteraction(e.getOriginalInteractionEvent());
+			abilityItem.setAmount(abilityItem.getAmount() - 1);
 		} else {
 			arena.getCooldowns().setAbilityCooldown(p.getName(), ability.getName());
 		}
-		
 	}
-	
+
 }

--- a/src/main/java/com/planetgallium/kitpvp/listener/ArenaListener.java
+++ b/src/main/java/com/planetgallium/kitpvp/listener/ArenaListener.java
@@ -25,263 +25,175 @@ import com.planetgallium.kitpvp.util.Toolkit;
 
 public class ArenaListener implements Listener {
 	
-	private Arena arena;
-	private Resources resources;
-	private Resource config;
+	private final Arena arena;
+	private final Resource config;
 	
 	public ArenaListener(Game plugin) {
 		this.arena = plugin.getArena();
-		this.resources = plugin.getResources();
-		this.config = resources.getConfig();
+		this.config = plugin.getResources().getConfig();
 	}
 	
 	@EventHandler
 	public void onBreak(BlockBreakEvent e) {
-		
 		Player p = e.getPlayer();
 		
 		if (Toolkit.inArena(p) && config.getBoolean("Arena.PreventBlockBreaking")) {
-			
 			e.setCancelled(!p.hasPermission("kp.arena.blockbreaking"));
-			
 		}
-		
 	}
 	
 	@EventHandler
 	public void onPlace(BlockPlaceEvent e) {
-
 		Player p = e.getPlayer();
 		
-		if (Toolkit.inArena(p)) {
-
-			if (config.getBoolean("Arena.PreventBlockPlacing")) {
-
-				e.setCancelled(!p.hasPermission("kp.arena.blockplacing"));
-
-			}
-			
+		if (Toolkit.inArena(p) && config.getBoolean("Arena.PreventBlockPlacing")) {
+			e.setCancelled(!p.hasPermission("kp.arena.blockplacing"));
 		}
 		
 	}
 	
 	@EventHandler
 	public void onItemDamage(PlayerItemDamageEvent e) {
-
 		if (Toolkit.inArena(e.getPlayer()) && config.getBoolean("Arena.PreventItemDurabilityDamage")) {
-
 			e.setCancelled(true);
-		
 		}
-		
 	}
 	
 	@EventHandler
 	public void onDrop(PlayerDropItemEvent e) {
-		
 		Player p = e.getPlayer();
 		
 		if (Toolkit.inArena(p) && config.getBoolean("Arena.PreventItemDropping")) {
-			
 			e.setCancelled(!p.hasPermission("kp.arena.itemdropping"));
-			
 		}
-		
 	}
 	
 	@EventHandler
 	public void onHunger(FoodLevelChangeEvent e) {
-		
 		Player p = (Player) e.getEntity();
 		
 		if (Toolkit.inArena(p) && config.getBoolean("Arena.PreventHunger")) {
-			
 			e.setCancelled(true);
-			
 		}
-		
 	}
 	
     @EventHandler
     public void onExplode(EntityExplodeEvent e) {
-	
     	if (Toolkit.inArena(e.getEntity()) && config.getBoolean("Arena.PreventBlockBreaking")) {
-
     		if (e.getEntityType() == EntityType.PRIMED_TNT) { // enable TNT explosion animation
     			e.blockList().clear();
     			e.setCancelled(false);
     			return;
 			}
-
 			e.setCancelled(true);
-			
 		}
-    
     }
 	
     @EventHandler
     public void onEntityDamage(EntityDamageByEntityEvent e) {
-
 		if (Toolkit.inArena(e.getEntity())) {
 
 			if (e.getEntity() instanceof Player && e.getDamager() instanceof Projectile) {
 
 				Player damagedPlayer = (Player) e.getEntity();
-
 				if (config.getBoolean("Arena.NoKitProtection")) {
-
-					if (!arena.getKits().hasKit(damagedPlayer.getName())) {
-
+					if (!arena.getKits().playerHasKit(damagedPlayer.getName())) {
 						e.setCancelled(true);
-
 					}
-
 				}
 
 			} else if (e.getEntity() instanceof Damageable) {
 
 				if (e.getDamager().getType() == EntityType.PRIMED_TNT) {
-
 					if (e.getEntity() instanceof ArmorStand || !(e.getEntity() instanceof LivingEntity)) {
 						// for preventing breakage of paintings, item frames, etc.
-
 						e.setCancelled(true);
-
 					}
-
 				}
 
 			}
-
 		}
-		
 	}
     
 	@EventHandler
 	public void onWeatherChange(WeatherChangeEvent e) {
-		
 		if (Toolkit.inArena(e.getWorld()) && config.getBoolean("Arena.KeepWeatherAtSunny")) {
-			
 			if (e.toWeatherState()) {
-			
 				e.setCancelled(true);
 				e.getWorld().setStorm(false);
 				e.getWorld().setThundering(false);
 				e.getWorld().setWeatherDuration(0);
-			
 			}
-			
 		}
-		
 	}
 	
 	@EventHandler
 	public void onExplosion(EntityDamageEvent e) {
-		
 		if (e.getEntity() instanceof Player) {
-		
 			Player damagedPlayer = (Player) e.getEntity();
 			
 			if (Toolkit.inArena(damagedPlayer)) {
-				
-				if (e.getCause() == DamageCause.BLOCK_EXPLOSION || e.getCause() == DamageCause.ENTITY_EXPLOSION || e.getCause() == DamageCause.FIRE || e.getCause() == DamageCause.FIRE_TICK) {
-					
+
+				if (e.getCause() == DamageCause.BLOCK_EXPLOSION ||
+						e.getCause() == DamageCause.ENTITY_EXPLOSION ||
+						e.getCause() == DamageCause.FIRE ||
+						e.getCause() == DamageCause.FIRE_TICK) {
 					if (config.getBoolean("Arena.NoKitProtection")) {
-
-						if (!arena.getKits().hasKit(damagedPlayer.getName())) {
-
+						if (!arena.getKits().playerHasKit(damagedPlayer.getName())) {
 							e.setCancelled(true);
-
 						}
-						
 					}
 				
 				} else if (e.getCause() == DamageCause.FALL) {
 
 					if (config.getBoolean("Arena.PreventFallDamage")) {
-
-						e.setCancelled(true); // only canceling if preventing fall damage is enabled, this allows for WorldGuard to step in
-
+						e.setCancelled(true);
+						// only canceling if preventing fall damage is enabled, this allows for WorldGuard to step in
 					}
 
 				} else if (damagedPlayer.getGameMode() == GameMode.SPECTATOR) {
-					
 					e.setCancelled(true);
-					
 				}
-				
 			}
-			
 		}
-		
 	}
 	
 	@EventHandler
 	public void onInteract(PlayerInteractEvent e) {
-		
 		Player p = e.getPlayer();
 		
 		if (Toolkit.inArena(p)) {
-			
-			if (Toolkit.getMainHandItem(p).getType() == XMaterial.ENDER_EYE.parseMaterial()) {
-				
-				e.setCancelled(true);
-				
-			}
-			
 			if (e.getClickedBlock() != null) {
-				
 				if (e.getClickedBlock().getType() == XMaterial.CHEST.parseMaterial()) {
-					
 					if (e.getAction() == Action.RIGHT_CLICK_BLOCK) {
-						
 						if (config.getBoolean("Arena.PreventChestOpen")) {
-							
 							e.setCancelled(true);
-							
 						}
-						
 					}
-					
 				}
-				
 			}
-			
 		}
-		
 	}
 	
 	@EventHandler
 	public void onPearl(PlayerTeleportEvent e) {
-		
 		Player p = e.getPlayer();
 		
 		if (Toolkit.inArena(p)) {
-			
 			if (e.getCause() == TeleportCause.ENDER_PEARL) {
-				
 				e.setCancelled(true);
 				p.teleport(e.getTo());
-				
 			}
-			
 		}
-		
 	}
 
 	@EventHandler
 	public void onHangingEntityBreakByTNT(HangingBreakEvent e) {
-
 		if (Toolkit.inArena(e.getEntity())) {
-
 			if (e.getCause() == HangingBreakEvent.RemoveCause.EXPLOSION) {
-
 				e.setCancelled(true);
-
 			}
-
 		}
-
 	}
 	
 }

--- a/src/main/java/com/planetgallium/kitpvp/listener/ArrowListener.java
+++ b/src/main/java/com/planetgallium/kitpvp/listener/ArrowListener.java
@@ -65,7 +65,7 @@ public class ArrowListener implements Listener {
 
 			// Do not do arrow return if damagedPlayer does not have a kit (if NoKitProtection is enabled)
 			if (config.getBoolean("Arena.NoKitProtection")) {
-				if (!plugin.getArena().getKits().hasKit(damagedPlayer.getName())) {
+				if (!plugin.getArena().getKits().playerHasKit(damagedPlayer.getName())) {
 					return;
 				}
 			}

--- a/src/main/java/com/planetgallium/kitpvp/listener/AttackListener.java
+++ b/src/main/java/com/planetgallium/kitpvp/listener/AttackListener.java
@@ -14,8 +14,8 @@ import com.planetgallium.kitpvp.util.Toolkit;
 
 public class AttackListener implements Listener {
 
-	private Resources resources;
-	private Kits kits;
+	private final Resources resources;
+	private final Kits kits;
 
 	public AttackListener(Game plugin) {
 		this.resources = plugin.getResources();
@@ -24,56 +24,35 @@ public class AttackListener implements Listener {
 	
 	@EventHandler
 	public void onDamageDealt(EntityDamageByEntityEvent e) {
-		
 		if (e.getEntity() instanceof Player && e.getDamager() instanceof Player) {
-			
 			Player damagedPlayer = (Player) e.getEntity();
 			Player damager = (Player) e.getDamager();
 			
 			if (Toolkit.inArena(damagedPlayer) && !damagedPlayer.hasMetadata("NPC")) {
-				
 				if (resources.getConfig().getBoolean("Arena.NoKitProtection")) {
-					
-					if (!kits.hasKit(damagedPlayer.getName())) {
-						
+					if (!kits.playerHasKit(damagedPlayer.getName())) {
 						damager.sendMessage(resources.getMessages().fetchString("Messages.Error.Invincible"));
 						e.setCancelled(true);
-						
 					}
 					
-					if (kits.hasKit(damagedPlayer.getName()) && !kits.hasKit(damager.getName())) {
-						
+					if (kits.playerHasKit(damagedPlayer.getName()) && !kits.playerHasKit(damager.getName())) {
 						damager.sendMessage(resources.getMessages().fetchString("Messages.Error.Kit"));
 						e.setCancelled(true);
-						
 					}
-					
 				}
-				
 			}
-			
-		} 
-		
+		}
 	}
 	
 	@EventHandler
 	public void onDamage(EntityDamageEvent e) {
 		if (e.getEntity() instanceof Player) {
 			Player damagedPlayer = (Player) e.getEntity();
-//			System.out.println("Damaged player: " + damagedPlayer.getName());
-
-			// bot is not doing damage to the player
 
 			if (Toolkit.inArena(damagedPlayer)) {
-//				System.out.println("Damaged player is in arena");
 				if (resources.getConfig().getBoolean("Arena.NoKitProtection")) {
-//					System.out.println("NoKitProt enabled");
-
-
-					if (!kits.hasKit(damagedPlayer.getName())) {
-//						System.out.println("has kit");
+					if (!kits.playerHasKit(damagedPlayer.getName())) {
 						if (e.getCause() != DamageCause.VOID) {
-//							System.out.println("Cancelled damage");
 							e.setCancelled(true);
 						}
 					}

--- a/src/main/java/com/planetgallium/kitpvp/listener/ChatListener.java
+++ b/src/main/java/com/planetgallium/kitpvp/listener/ChatListener.java
@@ -22,9 +22,7 @@ public class ChatListener implements Listener {
 	
 	@EventHandler
 	public void onChat(AsyncPlayerChatEvent e) {
-		
 		if (resources.getConfig().getBoolean("Chat.Enabled") && Toolkit.inArena(e.getPlayer())) {
-			
 			Player p = e.getPlayer();
 			String levelPrefix = arena.getUtilities().getPlayerLevelPrefix(p.getName());
 
@@ -34,9 +32,7 @@ public class ChatListener implements Listener {
 					.replace("%level%", levelPrefix);
 
 			e.setFormat(Toolkit.addPlaceholdersIfPossible(p, format));
-
 		}
-
 	}
 
 }

--- a/src/main/java/com/planetgallium/kitpvp/listener/DeathListener.java
+++ b/src/main/java/com/planetgallium/kitpvp/listener/DeathListener.java
@@ -41,7 +41,6 @@ public class DeathListener implements Listener {
 
 	@EventHandler
 	public void onDeath(PlayerDeathEvent e) {
-
 		// investigate possible memory leak when FancyDeath is enabled
 		if (Toolkit.inArena(e.getEntity())) {
 
@@ -161,7 +160,6 @@ public class DeathListener implements Listener {
 	}
 
 	private void setDeathMessage(Player victim) {
-
 		if (victim.getLastDamageCause() == null) {
 			broadcast(victim.getWorld(), getDeathMessage(victim, null, "Unknown"));
 			return;
@@ -170,7 +168,6 @@ public class DeathListener implements Listener {
 		DamageCause cause = victim.getLastDamageCause().getCause();
 
 		if (cause == DamageCause.PROJECTILE && getShooter(victim.getLastDamageCause()).getType() == EntityType.PLAYER) {
-
 			Player killer = (Player) getShooter(victim.getLastDamageCause());
 
 			broadcast(victim.getWorld(), getDeathMessage(victim, killer, "Shot"));
@@ -182,22 +179,20 @@ public class DeathListener implements Listener {
 //			creditWithKill(victim, victim.getKiller());
 
 		} else if (victim.getKiller() != null) {
-
 			Player killer = victim.getKiller();
 
 			broadcast(victim.getWorld(), getDeathMessage(victim, killer, "Player"));
 			creditWithKill(victim, killer);
 
 		} else if (arena.getHitCache().get(victim.getName()) != null) {
-
 			String killerName = arena.getHitCache().get(victim.getName());
 			Player killer = Toolkit.getPlayer(victim.getWorld(), killerName);
 
 			broadcast(victim.getWorld(), getDeathMessage(victim, killer, "Player"));
 			creditWithKill(victim, killer);
 
-		} else if ((cause == DamageCause.BLOCK_EXPLOSION || cause == DamageCause.ENTITY_EXPLOSION) && getExplodedEntity(victim.getLastDamageCause()).getType() == EntityType.PRIMED_TNT) {
-
+		} else if ((cause == DamageCause.BLOCK_EXPLOSION || cause == DamageCause.ENTITY_EXPLOSION) &&
+				getExplodedEntity(victim.getLastDamageCause()).getType() == EntityType.PRIMED_TNT) {
 			String bomberName = getExplodedEntity(victim.getLastDamageCause()).getCustomName();
 			Player killer = Toolkit.getPlayer(victim.getWorld(), bomberName);
 
@@ -205,40 +200,31 @@ public class DeathListener implements Listener {
 			creditWithKill(victim, killer);
 
 		} else if (cause == DamageCause.VOID) {
-
 			broadcast(victim.getWorld(), getDeathMessage(victim, null, "Void"));
 
 		} else if (cause == DamageCause.FALL) {
-
 			broadcast(victim.getWorld(), getDeathMessage(victim, null, "Fall"));
 
 		} else if (cause == DamageCause.FIRE || cause == DamageCause.FIRE_TICK || cause == DamageCause.LAVA) {
-
 			broadcast(victim.getWorld(), getDeathMessage(victim, null, "Fire"));
 
 		} else if (cause == DamageCause.BLOCK_EXPLOSION || cause == DamageCause.ENTITY_EXPLOSION) {
-
 			broadcast(victim.getWorld(), getDeathMessage(victim, null, "Explosion"));
 
 		} else {
-
 			broadcast(victim.getWorld(), getDeathMessage(victim, null, "Unknown"));
 
 		}
-		
 	}
 
 	private Entity getShooter(EntityDamageEvent e) {
-
 		EntityDamageByEntityEvent shotEvent = (EntityDamageByEntityEvent) e;
 		Projectile damager = (Projectile) shotEvent.getDamager();
 
 		return (Entity) damager.getShooter();
-
 	}
 
 	private Entity getExplodedEntity(EntityDamageEvent e) {
-
 //		if (e instanceof EntityDamageByBlockEvent) {
 //			EntityDamageByBlockEvent blownUpEvent2 = (EntityDamageByBlockEvent) e;
 //			return blownUpEvent2.getDamager();
@@ -246,7 +232,6 @@ public class DeathListener implements Listener {
 			EntityDamageByEntityEvent blownUpEvent = (EntityDamageByEntityEvent) e;
 			return blownUpEvent.getDamager();
 		/*}*/
-
 	}
 
 	private void creditWithKill(Player victim, Player killer) {
@@ -272,7 +257,6 @@ public class DeathListener implements Listener {
 	}
 
 	private String getDeathMessage(Player victim, Player killer, String type) {
-
 		String deathMessage = config.fetchString("Death.Messages." + type);
 
 		if (victim != null && killer != null) {
@@ -293,7 +277,6 @@ public class DeathListener implements Listener {
 		}
 
 		return deathMessage;
-
 	}
 
 	private void broadcast(World world, String message) {

--- a/src/main/java/com/planetgallium/kitpvp/listener/DeathListener.java
+++ b/src/main/java/com/planetgallium/kitpvp/listener/DeathListener.java
@@ -51,6 +51,8 @@ public class DeathListener implements Listener {
 				e.getDrops().clear();
 			}
 
+			CacheManager.getPotionSwitcherUsers().remove(victim.getName());
+
 			respawnPlayer(victim);
 			setDeathMessage(victim);
 
@@ -65,8 +67,7 @@ public class DeathListener implements Listener {
 			Toolkit.runCommands(victim, config.getStringList("Death.Commands"), "%victim%", victim.getName());
 
 			broadcast(victim.getWorld(),
-					XSound.matchXSound(config.fetchString("Death.Sound.Sound")).get().parseSound(),
-					1,
+					config.fetchString("Death.Sound.Sound"),
 					config.getInt("Death.Sound.Pitch"));
 		}
 
@@ -117,7 +118,7 @@ public class DeathListener implements Listener {
 								config.fetchString("Death.Title.Title"),
 								config.fetchString("Death.Title.Subtitle")
 										.replace("%seconds%", String.valueOf(time)));
-						XSound.play(victim, "UI_BUTTON_CLICK, 1, 1");
+						Toolkit.playSoundToPlayer(victim, "UI_BUTTON_CLICK", 1);
 						time--;
 					} else {
 						doClearInventoryOnRespawnIfEnabled(victim);
@@ -126,7 +127,7 @@ public class DeathListener implements Listener {
 
 						victim.sendMessage(config.fetchString("Death.Title.Message"));
 						victim.addPotionEffect(new PotionEffect(PotionEffectType.BLINDNESS, 30, 0));
-						XSound.play(victim, "ENTITY_EXPERIENCE_ORB_PICKUP, 1, 1");
+						Toolkit.playSoundToPlayer(victim, "ENTITY_EXPERIENCE_ORB_PICKUP", 1);
 
 						Toolkit.runCommands(victim, config.getStringList("Respawn.Commands"), "none", "none");
 
@@ -287,10 +288,10 @@ public class DeathListener implements Listener {
 		}
 	}
 
-	private void broadcast(World world, Sound sound, int volume, int pitch) {
+	private void broadcast(World world, String soundName, int pitch) {
 		if (config.getBoolean("Death.Sound.Enabled")) {
 			for (Player all : world.getPlayers()) {
-				XSound.play(all, String.format("%s, %d, %d", sound.toString(), volume, pitch));
+				Toolkit.playSoundToPlayer(all, soundName, pitch);
 			}
 		}
 	}

--- a/src/main/java/com/planetgallium/kitpvp/listener/DeathListener.java
+++ b/src/main/java/com/planetgallium/kitpvp/listener/DeathListener.java
@@ -121,10 +121,7 @@ public class DeathListener implements Listener {
 						XSound.play(victim, "UI_BUTTON_CLICK, 1, 1");
 						time--;
 					} else {
-						if (config.getBoolean("Arena.ClearInventoryOnRespawn")) {
-							victim.getInventory().clear();
-							victim.getInventory().setArmorContents(null);
-						}
+						doClearInventoryOnRespawnIfEnabled(victim);
 
 						arena.addPlayer(victim, true, config.getBoolean("Arena.GiveItemsOnRespawn"));
 
@@ -141,11 +138,7 @@ public class DeathListener implements Listener {
 
 		} else {
 			arena.removePlayer(victim);
-
-			if (config.getBoolean("Arena.ClearInventoryOnRespawn")) {
-				victim.getInventory().clear();
-				victim.getInventory().setArmorContents(null);
-			}
+			doClearInventoryOnRespawnIfEnabled(victim);
 
 			new BukkitRunnable() {
 				@Override
@@ -155,6 +148,15 @@ public class DeathListener implements Listener {
 							"none", "none");
 				}
 			}.runTaskLater(plugin, 1L);
+		}
+	}
+
+	private void doClearInventoryOnRespawnIfEnabled(Player victim) {
+		if (config.getBoolean("Arena.ClearInventoryOnRespawn")) {
+			victim.getInventory().clear();
+			victim.getInventory().setArmorContents(null);
+			victim.setItemOnCursor(null);
+			victim.getOpenInventory().getTopInventory().clear();
 		}
 	}
 

--- a/src/main/java/com/planetgallium/kitpvp/listener/HitListener.java
+++ b/src/main/java/com/planetgallium/kitpvp/listener/HitListener.java
@@ -26,25 +26,19 @@ public class HitListener implements Listener {
 
 	@EventHandler
 	public void onHit(EntityDamageByEntityEvent e) {
-
 		if (e.getEntity() instanceof Player && e.getDamager() instanceof Player) {
-
 			Player damager = (Player) e.getDamager();
 			Player damagedPlayer = (Player) e.getEntity();
 
 			if (Toolkit.inArena(damagedPlayer)) {
-
 				arena.getHitCache().put(damagedPlayer.getName(), damager.getName());
 
 				if (config.getBoolean("Combat.HitSound.Enabled")) {
 					hitSound.forPlayer(damagedPlayer).play();
 					hitSound.forPlayer(damager).play();
 				}
-
 			}
-
 		}
-		 
 	}
 	
 }

--- a/src/main/java/com/planetgallium/kitpvp/listener/HitListener.java
+++ b/src/main/java/com/planetgallium/kitpvp/listener/HitListener.java
@@ -34,8 +34,7 @@ public class HitListener implements Listener {
 				arena.getHitCache().put(damagedPlayer.getName(), damager.getName());
 
 				if (config.getBoolean("Combat.HitSound.Enabled")) {
-					hitSound.forPlayer(damagedPlayer).play();
-					hitSound.forPlayer(damager).play();
+					hitSound.soundPlayer().forPlayers(damagedPlayer, damager);
 				}
 			}
 		}

--- a/src/main/java/com/planetgallium/kitpvp/listener/ItemListener.java
+++ b/src/main/java/com/planetgallium/kitpvp/listener/ItemListener.java
@@ -5,6 +5,7 @@ import com.planetgallium.kitpvp.Game;
 import com.planetgallium.kitpvp.api.Kit;
 import com.planetgallium.kitpvp.game.Arena;
 import com.planetgallium.kitpvp.game.Utilities;
+import com.planetgallium.kitpvp.util.CacheManager;
 import com.planetgallium.kitpvp.util.Resource;
 import com.planetgallium.kitpvp.util.Resources;
 import com.planetgallium.kitpvp.util.Toolkit;
@@ -80,9 +81,10 @@ public class ItemListener implements Listener {
 
 			} else if (isAbility(p, interactedItem, "Witch", "GLASS_BOTTLE")) {
 				e.setCancelled(true);
+				CacheManager.getPotionSwitcherUsers().add(p.getName());
 				Toolkit.setHandItemForInteraction(e, createWitchPotion());
 
-			} else if (Toolkit.hasMatchingMaterial(interactedItem, "SPLASH_POTION")) {
+			} else if (isSplashPotion(interactedItem)) {
 				witchAbility(e, p, interactedItem, interactedItemMeta);
 
 			} else if ((Toolkit.hasMatchingMaterial(interactedItem, "SLIME_BALL") ||
@@ -360,7 +362,7 @@ public class ItemListener implements Listener {
 				@Override
 				public void run() {
 					Kit playerKit = arena.getKits().getKitOfPlayer(p.getName());
-					if (playerKit != null && playerKit.getName().equals("Witch")) {
+					if (playerKit != null && CacheManager.getPotionSwitcherUsers().contains(p.getName())) {
 						slotUsed.placeItemInSlot(p, randomizedWitchPotion);
 
 						if (abilities.getBoolean("Abilities.Witch.Message.Enabled")) {
@@ -369,6 +371,8 @@ public class ItemListener implements Listener {
 
 						Toolkit.playSoundToPlayer(p, abilities.fetchString("Abilities.Witch.Sound.Sound"),
 								abilities.getInt("Abliities.Witch.Sound.Pitch"));
+
+						CacheManager.getPotionSwitcherUsers().add(p.getName());
 					}
 				}
 			}.runTaskLater(plugin, 5 * 20L);
@@ -485,7 +489,8 @@ public class ItemListener implements Listener {
 	}
 
 	private int getItemByMeta(Material type, String displayName, Player p) {
-		for (int i = 0; i <= 45; i++) {
+		int inventorySize = Toolkit.versionToNumber() == 18 ? 39 : 45;
+		for (int i = 0; i <= inventorySize; i++) {
 			ItemStack item = p.getInventory().getItem(i);
 			if (item != null) {
 				if (item.getType() == type && Toolkit.hasMatchingDisplayName(item, displayName)) {
@@ -526,6 +531,11 @@ public class ItemListener implements Listener {
 			potion = PotionType.SLOWNESS;
 		}
 		return potion;
+	}
+
+	public boolean isSplashPotion(ItemStack item) {
+		int serverVersion = Toolkit.versionToNumber();
+		return Toolkit.hasMatchingMaterial(item, serverVersion == 18 ? "POTION" : "SPLASH_POTION");
 	}
 
 }

--- a/src/main/java/com/planetgallium/kitpvp/listener/ItemListener.java
+++ b/src/main/java/com/planetgallium/kitpvp/listener/ItemListener.java
@@ -60,6 +60,10 @@ public class ItemListener implements Listener {
 
 		if (Toolkit.inArena(p) && (e.getAction() == Action.RIGHT_CLICK_AIR || e.getAction() == Action.RIGHT_CLICK_BLOCK)) {
 
+			if (Toolkit.itemUsedIsOffhand(e)) {
+				return; // PlayerInteractEvent is triggered twice if there is an item in the offhand
+			}
+
 			ItemStack item = Toolkit.getMainHandItem(p);
 			ItemMeta meta = item.getItemMeta();
 

--- a/src/main/java/com/planetgallium/kitpvp/listener/MenuListener.java
+++ b/src/main/java/com/planetgallium/kitpvp/listener/MenuListener.java
@@ -3,17 +3,13 @@ package com.planetgallium.kitpvp.listener;
 import com.planetgallium.kitpvp.Game;
 import com.planetgallium.kitpvp.game.Arena;
 import com.planetgallium.kitpvp.menu.KitHolder;
-import com.planetgallium.kitpvp.menu.KitMenu;
 import com.planetgallium.kitpvp.menu.PreviewHolder;
-import com.planetgallium.kitpvp.menu.PreviewMenu;
-import com.planetgallium.kitpvp.util.CacheManager;
 import com.planetgallium.kitpvp.util.Resource;
 import com.planetgallium.kitpvp.util.Toolkit;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
 import org.bukkit.event.inventory.*;
-import org.bukkit.event.player.PlayerDropItemEvent;
 import org.bukkit.inventory.Inventory;
 import org.bukkit.scheduler.BukkitRunnable;
 
@@ -33,9 +29,7 @@ public class MenuListener implements Listener {
 
     @EventHandler
     public void onClick(InventoryClickEvent e) {
-
         if (e.getClickedInventory() != null) {
-
             Player p = (Player) e.getWhoClicked();
 
             Inventory originInventory = e.getClickedInventory();
@@ -56,56 +50,42 @@ public class MenuListener implements Listener {
                 String itemPath = "Menu.Items." + e.getSlot();
 
                 if (menuConfig.contains(itemPath)) {
-
                     if (openMenu.getItem(e.getSlot()) != null) {
-
                         e.setCancelled(true);
                         p.closeInventory();
 
                         String clickType = e.getClick() == ClickType.LEFT ? "Left-Click" : "Right-Click";
 
                         if (menuConfig.contains(itemPath + ".Commands")) {
-
                             new BukkitRunnable() {
-
                                 @Override
                                 public void run() {
-                                    Toolkit.runCommands(p, menuConfig.getStringList(itemPath + ".Commands." + clickType), "none", "none");
+                                    Toolkit.runCommands(p,
+                                            menuConfig.getStringList(itemPath + ".Commands." + clickType),
+                                            "none", "none");
                                 }
-
                             }.runTaskLater(plugin, 1L);
-
                         }
-
                     }
-
                 }
 
             } else if (e.getClickedInventory().getHolder() instanceof PreviewHolder) {
 
                 if (e.getSlot() == 8) {
-
                     p.closeInventory();
 
                     new BukkitRunnable() {
-
                         @Override
                         public void run() {
                             Toolkit.runCommands(p, config.getStringList("PreviewMenuBackArrowCommands"), "none", "none");
                         }
-
                     }.runTaskLater(plugin, 1L);
 
                 } else {
-
                     e.setCancelled(true);
-
                 }
-
             }
-
         }
-
     }
 
 }

--- a/src/main/java/com/planetgallium/kitpvp/listener/SignListener.java
+++ b/src/main/java/com/planetgallium/kitpvp/listener/SignListener.java
@@ -36,9 +36,7 @@ public class SignListener implements Listener {
 	
 	@EventHandler
 	public void onSignChange(SignChangeEvent e) {
-
 		if (e.getLine(0) != null && e.getLine(0).equalsIgnoreCase("[KitPvP]")) {
-			
 			Player p = e.getPlayer();
 			String signType = e.getLine(1);
 
@@ -51,23 +49,18 @@ public class SignListener implements Listener {
 				renameSign(e, "Signs." + Toolkit.capitalizeFirstChar(signType), placeholderKey, placeholderValue);
 				p.sendMessage(messages.fetchString("Messages.Other.Sign"));
 			}
-			
 		}
-		
 	}
 	
 	@EventHandler
 	public void onSignUse(PlayerInteractEvent e) {
-
 		// Logic behind this specific sign feature implementation: to avoid storing signs, most signs will
 		// either match what is specified in the config 100%, or essentially 95%, where the other 5% may be one word
 		// that is different (for instance a specified kit name, or arena name).
 		// If there isn't a 100% match, a search for that one word delta will be started and subsequently used if found.
 
 		if (e.getAction() == Action.RIGHT_CLICK_BLOCK) {
-			
 			if (e.getClickedBlock() != null && e.getClickedBlock().getState() instanceof Sign) {
-
 				ConfigurationSection signsSection = signs.getConfigurationSection("Signs");
 				Sign sign = (Sign) e.getClickedBlock().getState();
 				Player p = e.getPlayer();
@@ -93,32 +86,22 @@ public class SignListener implements Listener {
 						executeSign(p, signType, getWordDelta(mismatchedLines));
 						break;
 					}
-
 				}
-				
 			}
-			
 		}
-		
 	}
 	
 	private void renameSign(SignChangeEvent e, String path, String placeholder, String placeholderValue) {
-		
 		for (int i = 0; i < 3; i++) {
-
 			String line = signs.fetchString(path + ".Line-" + (i + 1));
 
 			if (placeholder != null && placeholderValue != null)
 				line = line.replace(placeholder, placeholderValue);
-
 			e.setLine(i, line);
-			
 		}
-		
 	}
 
 	private String getWordDelta(List<String[]> mismatchedLines) {
-
 		List<String> wordDelta = new ArrayList<>();
 
 		String rawConfigSignLine = ChatColor.stripColor(mismatchedLines.get(0)[0]);
@@ -138,11 +121,9 @@ public class SignListener implements Listener {
 
 		// if too many words differ, sign is not a match, return null
 		return wordDelta.size() > 1 ? null : wordDelta.get(0);
-
 	}
 
 	private void executeSign(Player p, String type, String placeholder) {
-
 		switch (type.toLowerCase()) {
 			case "refill":
 				arena.getMenus().getRefillMenu().open(p);
@@ -159,7 +140,6 @@ public class SignListener implements Listener {
 				p.performCommand("kp arena " + arenaName);
 				break;
 		}
-
 	}
 	
 }

--- a/src/main/java/com/planetgallium/kitpvp/listener/SoupListener.java
+++ b/src/main/java/com/planetgallium/kitpvp/listener/SoupListener.java
@@ -1,7 +1,5 @@
 package com.planetgallium.kitpvp.listener;
 
-import com.cryptomorin.xseries.XMaterial;
-import com.cryptomorin.xseries.XSound;
 import com.planetgallium.kitpvp.util.*;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
@@ -20,132 +18,83 @@ public class SoupListener implements Listener {
 	private final Game plugin;
 	private final Resource config;
 	private final int soupBoost;
-	
+	private final ItemStack soup;
+
 	public SoupListener(Game plugin) {
 		this.plugin = plugin;
 		this.config = plugin.getResources().getConfig();
+		// TODO: see if doing /kp reload works on this
 		this.soupBoost = plugin.getConfig().getInt("Soups.RegenAmount");
+
+		// TODO: see if doing /kp reload works on this
+		this.soup = Toolkit.safeItemStack("MUSHROOM_STEW");
+		ItemMeta soupMeta = soup.getItemMeta();
+		soupMeta.setDisplayName(config.fetchString("Soups.Name"));
+		soupMeta.setLore(Toolkit.colorizeList(config.getStringList("Soups.Lore")));
+		soup.setItemMeta(soupMeta);
 	}
 	
 	@EventHandler
-	public void onDamage(PlayerDeathEvent e) {
-		
+	public void onPlayerDeath(PlayerDeathEvent e) {
 		Player victim = e.getEntity();
-		
-		if (Toolkit.inArena(victim)) {
-			
-			if (victim.getKiller() != null && victim.getKiller() instanceof Player) {
-				
-				Player killer = victim.getKiller();
-				
-				if (config.getBoolean("Kill.SoupReward.Enabled")) {
-					
-					if (killer.hasPermission("kp.soupreturn")) {
-					
-						new BukkitRunnable() {
-							
-							@Override
-							public void run() {
-								
-								if (killer != null) { // incase they logged off
-									
-									int count = 0;
-									for (int i = 0; i < 36; i++) {
-										if (killer.getInventory().getItem(i) == null) {
-											count++;
-										}
-									}
-									
-									if (count < config.getInt("Kill.SoupReward.Amount")) {
-										killer.sendMessage(config.fetchString("Kill.SoupReward.NoSpace").replace("%amount%", String.valueOf((config.getInt("Kill.SoupReward.Amount") - count))));
-									} else {
-										count = config.getInt("Kill.SoupReward.Amount");
-									}
 
-									ItemStack soup = XMaterial.MUSHROOM_STEW.parseItem();
-									ItemMeta soupMeta = soup.getItemMeta();
-
-									soupMeta.setDisplayName(config.fetchString("Soups.Name"));
-									soupMeta.setLore(Toolkit.colorizeList(config.getStringList("Soups.Lore")));
-
-									soup.setItemMeta(soupMeta);
-
-									for (int r = 0; r < count; r++) {
-										killer.getInventory().addItem(soup);
-									}
-									
-								}
-								
-							}
-							
-						}.runTaskLater(plugin, config.getInt("Kill.SoupReward.Delay") * 20);
-						
-					}
-					
-				}
-				
-			}
-			
+		if (!Toolkit.inArena(victim)) {
+			return;
 		}
-		
+			
+		if (victim.getKiller() != null && config.getBoolean("Kill.SoupReward.Enabled")) {
+			Player killer = victim.getKiller();
+
+			if (!killer.hasPermission("kp.soupreturn")) {
+				return;
+			}
+
+			new BukkitRunnable() {
+				@Override
+				public void run() {
+					if (killer.isOnline()) {
+						insertSoupRewardToInventory(killer);
+					}
+				}
+			}.runTaskLater(plugin, config.getInt("Kill.SoupReward.Delay") * 20L);
+		}
+	}
+
+	private void insertSoupRewardToInventory(Player killer) {
+		for (int i = config.getInt("Kill.SoupReward.Amount"); i > 0; i--) {
+			if (killer.getInventory().firstEmpty() == -1) {
+				killer.sendMessage(config.fetchString("Kill.SoupReward.NoSpace")
+						.replace("%amount%", String.valueOf(i)));
+				break;
+			} else {
+				killer.getInventory().addItem(soup);
+			}
+		}
 	}
 	
 	@EventHandler
-	public void useSoup(PlayerInteractEvent e) {
-	    
-		if (config.getBoolean("Soups.Enabled")) {
-			
-			Player p = e.getPlayer();
-			
-			if (Toolkit.inArena(p)) {
-
-				if (e.getAction() == Action.RIGHT_CLICK_AIR || e.getAction() == Action.RIGHT_CLICK_BLOCK) {
-
-					if (Toolkit.getMainHandItem(p).getType() == XMaterial.MUSHROOM_STEW.parseMaterial() || Toolkit.getOffhandItem(p).getType() == XMaterial.MUSHROOM_STEW.parseMaterial()) {
-
-						e.setCancelled(true);
-
-						if (p.getHealth() < 20.0) {
-
-							p.setHealth(p.getHealth() + (double) soupBoost >= 20.0 ? 20.0 : p.getHealth() + (double) soupBoost);
-							p.playSound(p.getLocation(), XSound.matchXSound(config.fetchString("Soups.Sound")).get().parseSound(), 1, (float) config.getInt("Soups.Pitch"));
-
-							if (Toolkit.getMainHandItem(p).getType() == XMaterial.MUSHROOM_STEW.parseMaterial()) {
-
-								if (config.getBoolean("Soups.RemoveAfterUse")) {
-
-									Toolkit.setMainHandItem(p, new ItemStack(XMaterial.AIR.parseItem()));
-
-								} else {
-
-									Toolkit.setMainHandItem(p, new ItemStack(XMaterial.BOWL.parseItem()));
-
-								}
-
-							} else if (Toolkit.getOffhandItem(p).getType() == XMaterial.MUSHROOM_STEW.parseMaterial()) {
-
-								if (config.getBoolean("Soups.RemoveAfterUse")) {
-
-									Toolkit.setOffhandItem(p, new ItemStack(XMaterial.AIR.parseItem()));
-
-								} else {
-
-									Toolkit.setOffhandItem(p, new ItemStack(XMaterial.BOWL.parseItem()));
-
-								}
-
-							}
-
-						}
-
-					}
-
-				}
-				
-			}
-			
+	public void onSoupUse(PlayerInteractEvent e) {
+		if (!config.getBoolean("Soups.Enabled")) {
+			return;
 		}
-		
+
+		Player p = e.getPlayer();
+
+		if (Toolkit.inArena(p) &&
+				(e.getAction() == Action.RIGHT_CLICK_AIR || e.getAction() == Action.RIGHT_CLICK_BLOCK)) {
+			if (Toolkit.hasMatchingMaterial(Toolkit.getHandItemForInteraction(e), "MUSHROOM_STEW")) {
+				e.setCancelled(true);
+
+				if (p.getHealth() < 20.0) {
+					p.setHealth(Math.min(p.getHealth() + (double) soupBoost, 20.0));
+
+					Toolkit.playSoundToPlayer(p, config.fetchString("Soups.Sound"),
+							config.getInt("Soups.Pitch"));
+					Toolkit.setHandItemForInteraction(e,config.getBoolean("Soups.RemoveAfterUse") ?
+							Toolkit.safeItemStack("AIR") : Toolkit.safeItemStack("BOWL"));
+				}
+			}
+		}
 	}
 	
 }

--- a/src/main/java/com/planetgallium/kitpvp/listener/SoupListener.java
+++ b/src/main/java/com/planetgallium/kitpvp/listener/SoupListener.java
@@ -17,21 +17,10 @@ public class SoupListener implements Listener {
 
 	private final Game plugin;
 	private final Resource config;
-	private final int soupBoost;
-	private final ItemStack soup;
 
 	public SoupListener(Game plugin) {
 		this.plugin = plugin;
 		this.config = plugin.getResources().getConfig();
-		// TODO: see if doing /kp reload works on this
-		this.soupBoost = plugin.getConfig().getInt("Soups.RegenAmount");
-
-		// TODO: see if doing /kp reload works on this
-		this.soup = Toolkit.safeItemStack("MUSHROOM_STEW");
-		ItemMeta soupMeta = soup.getItemMeta();
-		soupMeta.setDisplayName(config.fetchString("Soups.Name"));
-		soupMeta.setLore(Toolkit.colorizeList(config.getStringList("Soups.Lore")));
-		soup.setItemMeta(soupMeta);
 	}
 	
 	@EventHandler
@@ -67,7 +56,7 @@ public class SoupListener implements Listener {
 						.replace("%amount%", String.valueOf(i)));
 				break;
 			} else {
-				killer.getInventory().addItem(soup);
+				killer.getInventory().addItem(buildSoup());
 			}
 		}
 	}
@@ -86,6 +75,8 @@ public class SoupListener implements Listener {
 				e.setCancelled(true);
 
 				if (p.getHealth() < 20.0) {
+					int soupBoost = plugin.getConfig().getInt("Soups.RegenAmount");
+
 					p.setHealth(Math.min(p.getHealth() + (double) soupBoost, 20.0));
 
 					Toolkit.playSoundToPlayer(p, config.fetchString("Soups.Sound"),
@@ -95,6 +86,17 @@ public class SoupListener implements Listener {
 				}
 			}
 		}
+	}
+
+	private ItemStack buildSoup() {
+		ItemStack soup = Toolkit.safeItemStack("MUSHROOM_STEW");
+		ItemMeta soupMeta = soup.getItemMeta();
+
+		soupMeta.setDisplayName(config.fetchString("Soups.Name"));
+		soupMeta.setLore(config.getStringList("Soups.Lore"));
+
+		soup.setItemMeta(soupMeta);
+		return soup;
 	}
 	
 }

--- a/src/main/java/com/planetgallium/kitpvp/listener/TrackerListener.java
+++ b/src/main/java/com/planetgallium/kitpvp/listener/TrackerListener.java
@@ -1,6 +1,5 @@
 package com.planetgallium.kitpvp.listener;
 
-import com.cryptomorin.xseries.XMaterial;
 import com.planetgallium.kitpvp.game.Arena;
 import com.planetgallium.kitpvp.util.Resources;
 import org.bukkit.entity.Player;
@@ -27,57 +26,47 @@ public class TrackerListener implements Listener {
 	}
 	
 	@EventHandler
-	public void onCompassHeld(PlayerItemHeldEvent event) {
-
-		if (!Toolkit.inArena(event.getPlayer())) {
+	public void onCompassHeld(PlayerItemHeldEvent e) {
+		if (!Toolkit.inArena(e.getPlayer())) {
 			return;
 		}
 
-		Player player = event.getPlayer();
-		ItemStack itemHeld = player.getInventory().getItem(event.getNewSlot());
+		Player p = e.getPlayer();
+		ItemStack itemHeld = p.getInventory().getItem(e.getNewSlot());
 
-		if (itemHeld != null && itemHeld.getType() == XMaterial.COMPASS.parseMaterial()) {
+		if (itemHeld != null && Toolkit.hasMatchingMaterial(itemHeld, "COMPASS")) {
 
 			new BukkitRunnable() {
-
 				@Override
 				public void run() {
-
 					// if the player using the compass leaves the server or no longer has a kit
-					if (!player.isOnline() || !arena.getKits().hasKit(player.getName())) {
+					if (!p.isOnline() || !arena.getKits().playerHasKit(p.getName())) {
 						cancel();
 						return;
 					}
 
 					if (resources.getConfig().getBoolean("PlayerTracker.RefreshOnlyWhenHeld")) {
-						ItemStack itemInHand = Toolkit.getMainHandItem(player);
-						if (itemInHand == null || itemInHand.getType() != XMaterial.COMPASS.parseMaterial()) {
+						if (!Toolkit.eitherHandHasMaterial(p, "COMPASS")) {
 							cancel();
 							return;
 						}
 					}
 
 					String[] nearestPlayerData = null;
-
-					if (player.getWorld().getPlayers().size() == 1) {
+					if (p.getWorld().getPlayers().size() == 1) {
 						cancel();
 					} else {
-						nearestPlayerData = Toolkit.getNearestPlayer(player,
+						nearestPlayerData = Toolkit.getNearestPlayer(p,
 												 resources.getConfig().getInt("PlayerTracker.TrackBelowY"));
 					}
 
-					updateTrackingCompass(player, itemHeld, nearestPlayerData);
-
+					updateTrackingCompass(p, itemHeld, nearestPlayerData);
 				}
-
 			}.runTaskTimer(plugin, 0L, 20L);
-
 		}
-		
 	}
 
 	private void updateTrackingCompass(Player player, ItemStack compass, String[] nearestPlayerData) {
-
 		ItemMeta compassMeta = compass.getItemMeta();
 
 		if (nearestPlayerData != null) {
@@ -88,7 +77,6 @@ public class TrackerListener implements Listener {
 				compassMeta.setDisplayName(resources.getConfig().fetchString("PlayerTracker.Message")
 												   .replace("%nearestplayer%", nearestPlayer.getName())
 												   .replace("%distance%", String.valueOf(nearestPlayerDistance)));
-
 				player.setCompassTarget(nearestPlayer.getLocation());
 			}
 		} else {
@@ -96,7 +84,6 @@ public class TrackerListener implements Listener {
 		}
 
 		compass.setItemMeta(compassMeta);
-
 	}
 	
 }

--- a/src/main/java/com/planetgallium/kitpvp/menu/KitMenu.java
+++ b/src/main/java/com/planetgallium/kitpvp/menu/KitMenu.java
@@ -1,6 +1,5 @@
 package com.planetgallium.kitpvp.menu;
 
-import com.cryptomorin.xseries.XMaterial;
 import com.planetgallium.kitpvp.util.*;
 import org.bukkit.Material;
 import org.bukkit.configuration.ConfigurationSection;
@@ -19,23 +18,19 @@ public class KitMenu {
 	}
 
 	private void create() {
-
 		this.menu = new Menu(resources.getMenu().fetchString("Menu.General.Title"), new KitHolder(), resources.getMenu().getInt("Menu.General.Size"));
 
 		ConfigurationSection section = resources.getMenu().getConfigurationSection("Menu.Items");
 
 		for (String slot : section.getKeys(false)) {
-
 			String itemPath = "Menu.Items." + slot;
 
 			String name = resources.getMenu().fetchString(itemPath + ".Name");
-			Material material = XMaterial.matchXMaterial(resources.getMenu().fetchString(itemPath + ".Material")).get().parseMaterial();
+			Material material = Toolkit.safeMaterial(resources.getMenu().fetchString(itemPath + ".Material"));
 			List<String> lore = resources.getMenu().getStringList(itemPath + ".Lore");
 
-			menu.addItem(name, material, lore, Integer.valueOf(slot));
-
+			menu.addItem(name, material, lore, Integer.parseInt(slot));
 		}
-
 	}
 
 	public void rebuildCache() {

--- a/src/main/java/com/planetgallium/kitpvp/menu/KitMenu.java
+++ b/src/main/java/com/planetgallium/kitpvp/menu/KitMenu.java
@@ -11,11 +11,11 @@ import java.util.List;
 public class KitMenu {
 
 	private Menu menu;
-	private Resources resources;
+	private final Resources resources;
 	
 	public KitMenu(Resources resources) {
 		this.resources = resources;
-		create();
+		rebuildCache();
 	}
 
 	private void create() {
@@ -38,7 +38,7 @@ public class KitMenu {
 
 	}
 
-	public void clearCache() {
+	public void rebuildCache() {
 		create();
 	}
 

--- a/src/main/java/com/planetgallium/kitpvp/menu/PreviewMenu.java
+++ b/src/main/java/com/planetgallium/kitpvp/menu/PreviewMenu.java
@@ -50,7 +50,7 @@ public class PreviewMenu {
 		}
 
 		String menuPotionEffectsItemName =
-				resources.getMessages().fetchString("Messages.Other.MenuPotionEffectsItemName");
+				resources.getMessages().fetchString("Messages.Other.PreviewMenuPotionEffectsItemName");
 		previewMenu.addItem(menuPotionEffectsItemName, XMaterial.BREWING_STAND.parseMaterial(), effectsLore, 4);
 
 		//			HOTBAR			//
@@ -79,7 +79,8 @@ public class PreviewMenu {
 			}
 		}
 
-		String menuBackArrowItemName = resources.getMessages().fetchString("Messages.Other.MenuBackArrowItemName");
+		String menuBackArrowItemName =
+				resources.getMessages().fetchString("Messages.Other.PreviewMenuBackArrowItemName");
 		previewMenu.addItem(menuBackArrowItemName, XMaterial.ARROW.parseMaterial(), new ArrayList<>(), 8);
 
 		CacheManager.getPreviewMenuCache().put(kit.getName(), previewMenu);

--- a/src/main/java/com/planetgallium/kitpvp/menu/RefillMenu.java
+++ b/src/main/java/com/planetgallium/kitpvp/menu/RefillMenu.java
@@ -1,13 +1,16 @@
 package com.planetgallium.kitpvp.menu;
 
-import com.cryptomorin.xseries.XMaterial;
 import com.planetgallium.kitpvp.util.Menu;
 import com.planetgallium.kitpvp.util.Resources;
+import com.planetgallium.kitpvp.util.Toolkit;
+import org.bukkit.Material;
 import org.bukkit.entity.Player;
+
+import java.util.List;
 
 public class RefillMenu {
 
-    private Resources resources;
+    private final Resources resources;
     private Menu menu;
 
     public RefillMenu(Resources resources) {
@@ -15,20 +18,18 @@ public class RefillMenu {
     }
 
     private void create() {
-
         this.menu = new Menu("Refill", null, 54);
 
         for (int i = 0; i < menu.getSize(); i++) {
-            menu.addItem(resources.getConfig().fetchString("Soups.Name"), XMaterial.MUSHROOM_STEW.parseMaterial(), resources.getConfig().getStringList("Soups.Lore"), i);
+            menu.addItem(resources.getConfig().fetchString("Soups.Name"),
+                    Toolkit.safeMaterial("MUSHROOM_STEW"),
+                    resources.getConfig().getStringList("Soups.Lore"), i);
         }
-
     }
 
     public void open(Player p) {
-
         create();
         menu.openMenu(p);
-
     }
 
 }

--- a/src/main/java/com/planetgallium/kitpvp/util/CacheManager.java
+++ b/src/main/java/com/planetgallium/kitpvp/util/CacheManager.java
@@ -24,7 +24,6 @@ public class CacheManager {
         if (!abilityCooldowns.containsKey(username)) {
             abilityCooldowns.put(username, new HashMap<>());
         }
-
         return abilityCooldowns.get(username);
     }
 

--- a/src/main/java/com/planetgallium/kitpvp/util/CacheManager.java
+++ b/src/main/java/com/planetgallium/kitpvp/util/CacheManager.java
@@ -11,6 +11,7 @@ public class CacheManager {
     private static final Map<String, Menu> previewMenuCache = new HashMap<>();
     private static final Map<String, Map<String, Long>> abilityCooldowns = new HashMap<>();
     private static final Map<String, PlayerData> statsCache = new HashMap<>();
+    private static final Set<String> potionSwitcherUsers = new HashSet<>();
 
     public static Map<String, String> getUUIDCache() { return usernameToUUID; }
 
@@ -19,6 +20,8 @@ public class CacheManager {
     public static Map<String, Menu> getPreviewMenuCache() { return previewMenuCache; }
 
     public static Map<String, PlayerData> getStatsCache() { return statsCache; }
+
+    public static Set<String> getPotionSwitcherUsers() { return potionSwitcherUsers; }
 
     public static Map<String, Long> getPlayerAbilityCooldowns(String username) {
         if (!abilityCooldowns.containsKey(username)) {

--- a/src/main/java/com/planetgallium/kitpvp/util/Cooldown.java
+++ b/src/main/java/com/planetgallium/kitpvp/util/Cooldown.java
@@ -8,16 +8,13 @@ public class Cooldown {
 	private int seconds;
 	
 	public Cooldown(int days, int hours, int minutes, int seconds) {
-		
 		this.days = days;
 		this.hours = hours;
 		this.minutes = minutes;
 		this.seconds = seconds;
-		
 	}
 	
 	public Cooldown(int seconds) {
-
 		if (seconds / 86400 > 0) {
 			this.days = seconds / 86400;
 			seconds -= (days * 86400);
@@ -36,41 +33,26 @@ public class Cooldown {
 		if (seconds > 0) {
 			this.seconds = seconds;
 		}
-		
 	}
 
 	public Cooldown(String formattedCooldown) {
-
 		String[] units = formattedCooldown.split(":");
 
 		for (int i = 0; i < units.length; i++) {
-
 			if (units[i].toUpperCase().endsWith("D")) {
-
 				days = Integer.parseInt(units[i].split("D")[0]);
-
 			} else if (units[i].toUpperCase().endsWith("H")) {
-
 				hours = Integer.parseInt(units[i].split("H")[0]);
-
 			} else if (units[i].toUpperCase().endsWith("M")) {
-
 				minutes = Integer.parseInt(units[i].split("M")[0]);
-
 			} else if (units[i].toUpperCase().endsWith("S")) {
-
 				seconds = Integer.parseInt(units[i].split("S")[0]);
-
 			}
-
 		}
-
 	}
 
 	public String formatted(boolean condensed) {
-
 		if (condensed) {
-
 			String condensedCooldown = "";
 
 			if (getDays() != 0) condensedCooldown += getDays() + "D:";
@@ -85,9 +67,7 @@ public class Cooldown {
 			}
 
 			return condensedCooldown;
-
 		} else {
-
 			String longCooldown = "";
 
 			if (getDays() != 0) longCooldown += (getDays() + " days ");
@@ -96,24 +76,18 @@ public class Cooldown {
 			if (getSeconds() != 0) longCooldown += (getSeconds() + " seconds");
 
 			if (longCooldown.length() > 0 && longCooldown.charAt(longCooldown.length() - 1) == ' ') {
-
 				longCooldown = longCooldown.substring(0, longCooldown.length() - 1);
-
 			}
 
 			return longCooldown;
-
 		}
-
 	}
 
 	public int toSeconds() {
-
 		int daysToSeconds = days * 86400;
 		int hoursToSeconds = hours * 3600;
 		int minutesToSeconds = minutes * 60;
 		return daysToSeconds + hoursToSeconds + minutesToSeconds + seconds;
-
 	}
 	
 	public int getDays() { return days; }

--- a/src/main/java/com/planetgallium/kitpvp/util/Menu.java
+++ b/src/main/java/com/planetgallium/kitpvp/util/Menu.java
@@ -3,7 +3,6 @@ package com.planetgallium.kitpvp.util;
 import java.util.List;
 
 import org.bukkit.Bukkit;
-import org.bukkit.ChatColor;
 import org.bukkit.Material;
 import org.bukkit.entity.Player;
 import org.bukkit.inventory.Inventory;
@@ -19,61 +18,49 @@ public class Menu {
 	private final InventoryHolder owner;
 	
 	public Menu(String title, InventoryHolder owner, int size) {
-		
-		menu = Bukkit.createInventory(owner, size, Toolkit.translate(title));
+		this.menu = Bukkit.createInventory(owner, size, Toolkit.translate(title));
 		this.title = title;
 		this.size = size;
 		this.owner = owner;
-		
 	}
 	
 	public void addItem(String name, Material material, List<String> lore, int slot) {
-		
 		ItemStack item = new ItemStack(material);
 		ItemMeta meta = item.getItemMeta();
-		
-		lore.replaceAll(s -> ChatColor.translateAlternateColorCodes('&', s));
+
+		Toolkit.colorizeList(lore);
 		
 		meta.setDisplayName(Toolkit.translate(name));
 		meta.setLore(lore);
 		item.setItemMeta(meta);
 		
 		menu.setItem(slot, item);
-		
 	}
 	
 	public void addItem(String name, Material material, List<String> lore, int amount, int slot) {
-		
 		ItemStack item = new ItemStack(material);
 		ItemMeta meta = item.getItemMeta();
-		
-		lore.replaceAll(s -> ChatColor.translateAlternateColorCodes('&', s));
-		
+
+		Toolkit.colorizeList(lore);
+
 		meta.setDisplayName(Toolkit.translate(name));
 		meta.setLore(lore);
 		item.setAmount(amount > 0 ? amount : 1);
 		item.setItemMeta(meta);
 		
 		menu.setItem(slot, item);
-		
 	}
 
 	public void setItem(ItemStack item, int slot) {
-
 		menu.setItem(slot, item);
-
 	}
 	
 	public void openMenu(Player p) {
-		
 		p.openInventory(menu);
-	
 	}
 	
 	public void closeMenu(Player p) {
-		
 		p.closeInventory();
-		
 	}
 	
 	public ItemStack getSlot(int slot) { return menu.getItem(slot); }

--- a/src/main/java/com/planetgallium/kitpvp/util/Placeholders.java
+++ b/src/main/java/com/planetgallium/kitpvp/util/Placeholders.java
@@ -35,13 +35,14 @@ public class Placeholders extends PlaceholderExpansion {
 	
 	@Override
 	public String onPlaceholderRequest(Player p, @NotNull String identifier) {
-		if (p == null) return null;
-
 		if (identifier.contains("top")) {
 			return handleLeaderboardPlaceholder(identifier);
 		}
 
-		return translatePlaceholderAPIPlaceholders(identifier, p.getName());
+		if (p != null) {
+			return translatePlaceholderAPIPlaceholders(identifier, p.getName());
+		}
+		return null;
 	}
 
 	private String handleLeaderboardPlaceholder(String identifier) {

--- a/src/main/java/com/planetgallium/kitpvp/util/Resource.java
+++ b/src/main/java/com/planetgallium/kitpvp/util/Resource.java
@@ -4,7 +4,6 @@ import java.io.*;
 import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Objects;
 
 import com.planetgallium.kitpvp.Game;
 import org.bukkit.ChatColor;
@@ -14,12 +13,12 @@ import org.bukkit.plugin.Plugin;
 
 public class Resource extends YamlConfiguration {
 
-	private String name;
+	private final String name;
 	private final File file;
-	private List<String> copyDefaultExemptions;
+	private final List<String> copyDefaultExemptions;
 
-	private Plugin plugin;
-	private String path;
+	private final Plugin plugin;
+	private final String path;
 
 	public Resource(Plugin plugin, String path) {
 		this.plugin = plugin;
@@ -31,7 +30,6 @@ public class Resource extends YamlConfiguration {
 	}
 
 	public void load() {
-
 		if (!file.getParentFile().exists()) {
 			file.getParentFile().mkdirs();
 		}
@@ -53,11 +51,9 @@ public class Resource extends YamlConfiguration {
 		} catch (IOException | InvalidConfigurationException e) {
 			e.printStackTrace();
 		}
-
 	}
 
 	public void copyDefaults() {
-
 		Reader defaultConfigSearchResult = null;
 
 		if (plugin.getResource(path) != null) {
@@ -80,7 +76,6 @@ public class Resource extends YamlConfiguration {
 			}
 			save();
 		}
-
 	}
 
 	public void addCopyDefaultExemption(String path) {
@@ -93,6 +88,12 @@ public class Resource extends YamlConfiguration {
 		} catch (IOException e) {
 			e.printStackTrace();
 		}
+	}
+
+	@Override
+	public String getString(String path) {
+		Toolkit.printToConsole("%prefix% &cNote: Do not use legacy resource.getString, use resource.fetchString instead");
+		return super.getString(path);
 	}
 
     public String fetchString(String path) {
@@ -111,18 +112,7 @@ public class Resource extends YamlConfiguration {
 
     @Override
 	public List<String> getStringList(String path) {
-		List<String> originalList = super.getStringList(path);
-
-		if (originalList != null) {
-			List<String> colorizedList = new ArrayList<>();
-			for (String line : originalList) {
-				colorizedList.add(ChatColor.translateAlternateColorCodes('&', line));
-			}
-			return colorizedList;
-		}
-
-		return originalList;
-
+		return Toolkit.colorizeList(super.getStringList(path));
 	}
 	
 	public String getName() { return name; }

--- a/src/main/java/com/planetgallium/kitpvp/util/Resources.java
+++ b/src/main/java/com/planetgallium/kitpvp/util/Resources.java
@@ -58,7 +58,6 @@ public class Resources {
 	}
 	
 	public void load() {
-
 		config.load();
 		abilities.load();
 		killstreaks.load();
@@ -104,7 +103,6 @@ public class Resources {
 		// Reload all kitName.yml, abilityName.yml
 		kitToResource.values().forEach(Resource::load);
 		abilityToResource.values().forEach(Resource::load);
-		
 	}
 	
 	public void reload() {

--- a/src/main/java/com/planetgallium/kitpvp/util/Resources.java
+++ b/src/main/java/com/planetgallium/kitpvp/util/Resources.java
@@ -90,24 +90,20 @@ public class Resources {
 
 		// load new kits & abilities that have been added through file system (when doing /kp reload)
 		for (String fileName : getPluginDirectoryFiles("kits", true)) {
-			if (!kitToResource.containsKey(fileName)) {
+			if (!kitToResource.containsKey(fileName) && !fileName.startsWith(".")) {
 				kitToResource.put(fileName, new Resource(plugin, "kits/" + fileName));
 			}
 		}
 
 		for (String fileName : getPluginDirectoryFiles("abilities", true)) {
-			if (!abilityToResource.containsKey(fileName)) {
+			if (!abilityToResource.containsKey(fileName) && !fileName.startsWith(".")) {
 				abilityToResource.put(fileName, new Resource(plugin, "abilities/" + fileName));
 			}
 		}
 
-		for (String fileName : kitToResource.keySet()) {
-			kitToResource.get(fileName).load();
-		}
-
-		for (String fileName : abilityToResource.keySet()) {
-			abilityToResource.get(fileName).load();
-		}
+		// Reload all kitName.yml, abilityName.yml
+		kitToResource.values().forEach(Resource::load);
+		abilityToResource.values().forEach(Resource::load);
 		
 	}
 	

--- a/src/main/java/com/planetgallium/kitpvp/util/Toolkit.java
+++ b/src/main/java/com/planetgallium/kitpvp/util/Toolkit.java
@@ -143,6 +143,8 @@ public class Toolkit {
 			return 118;
 		} else if (version.contains("1.19")) {
 			return 119;
+		} else if (version.contains("1.20")) {
+			return 120;
 		}
  		return 500;
  	}
@@ -464,6 +466,10 @@ public class Toolkit {
 			return itemMeta.hasLore() && itemMeta.getLore() != null && itemMeta.getLore().get(0).equals(expectedLore);
 		}
 		return false;
+	}
+
+	public static boolean isPluginEnabled(String pluginName) {
+		return Bukkit.getPluginManager().isPluginEnabled(pluginName);
 	}
 
 	public static class SlotWrapper {

--- a/src/main/java/com/planetgallium/kitpvp/util/Toolkit.java
+++ b/src/main/java/com/planetgallium/kitpvp/util/Toolkit.java
@@ -1,6 +1,5 @@
 package com.planetgallium.kitpvp.util;
 
-import java.io.File;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
@@ -14,6 +13,9 @@ import org.bukkit.attribute.AttributeInstance;
 import org.bukkit.configuration.file.FileConfiguration;
 import org.bukkit.entity.Entity;
 import org.bukkit.entity.Player;
+import org.bukkit.event.Event;
+import org.bukkit.event.entity.ProjectileLaunchEvent;
+import org.bukkit.event.player.PlayerInteractEntityEvent;
 import org.bukkit.event.player.PlayerInteractEvent;
 import org.bukkit.inventory.EquipmentSlot;
 import org.bukkit.inventory.ItemStack;
@@ -30,45 +32,32 @@ public class Toolkit {
 	private static final Material FALLBACK_MATERIAL = Material.BEDROCK;
 
 	public static boolean inArena(World world) {
-
 		if (Game.getInstance().getResources().getConfig().contains("Arenas")) {
 			return Game.getInstance().getResources().getConfig().contains("Arenas." + world.getName());
 		} else {
 			Toolkit.printToConsole("&7[&b&lKIT-PVP&7] &cThere was no spawn found, please set it using /kp addspawn.");
 		}
 		return false;
-
 	}
 	
 	public static boolean inArena(Entity entity) {
-		
 		return inArena(entity.getWorld());
-		
 	}
 	
  	public static String[] getNearestPlayer(Player player, int maxY) {
-		
 		String nearest = "player:100000.0";
-		
+
 		for (Player all : Bukkit.getWorld(player.getWorld().getName()).getPlayers()) {
-			
 			String[] list = nearest.split(":");
 			double cal = player.getLocation().distance(all.getLocation());
 			
 			if (cal <= Double.parseDouble(list[1]) && all != player) {
-
 				if (all.getLocation().getBlockY() < maxY) {
-
 					if (all.getGameMode() != GameMode.SPECTATOR) {
-
 						nearest = all.getName() + ":" + cal;
-
 					}
-
 				}
-				
 			}
-			
 		}
 		
 		if (nearest.equals("player:100000.0")) {
@@ -76,33 +65,28 @@ public class Toolkit {
 		}
 		
 		return nearest.split(":");
-		
 	}
  	
  	public static double round(double value, int precision) {
- 		
  	    int scale = (int) Math.pow(10, precision);
  	    return (double) Math.round(value * scale) / scale;
- 	    
  	}
  	
  	public static Color getColorFromConfig(FileConfiguration config, String path) {
- 		
  		return Color.fromRGB(config.getInt(path + ".Red"),
 				config.getInt(path + ".Green"),
 				config.getInt(path + ".Blue"));
- 		
  	}
 
  	public static void runCommands(Player p, List<String> commands, String replaceFrom, String replaceTo) {
-
 		if (commands == null) return;
 
 		for (String commandString : commands) {
 			String[] commandPhrase = commandString.split(":", 2);
 
 			if (commandPhrase.length == 1) {
-				Toolkit.printToConsole("&7[&b&lKIT-PVP&7] &cIncorrect command format. Please see: &fhttps://bit.ly/kp-command-format");
+				Toolkit.printToConsole("&7[&b&lKIT-PVP&7] &cIncorrect command format. " +
+						"Please see: &fhttps://bit.ly/kp-command-format");
 				return;
 			}
 
@@ -117,11 +101,11 @@ public class Toolkit {
 			} else if (sender.equals("player")) {
 				p.performCommand(replaceCommandPlaceholders(command, p, replaceFrom, replaceTo));
 			} else {
-				Toolkit.printToConsole("&7[&b&lKIT-PVP&7] &cIncorrect command format. Please see: &fhttps://bit.ly/kp-command-format");
+				Toolkit.printToConsole("&7[&b&lKIT-PVP&7] &cIncorrect command format. " +
+						"Please see: &fhttps://bit.ly/kp-command-format");
 				return;
 			}
 		}
-
 	}
 
 	private static String replaceCommandPlaceholders(String s, Player p, String replaceFrom, String replaceTo) {
@@ -133,7 +117,6 @@ public class Toolkit {
 	}
  	
  	public static int versionToNumber() {
-
 		String version = Bukkit.getVersion();
 
 		if (version.contains("1.8")) {
@@ -162,63 +145,10 @@ public class Toolkit {
 			return 119;
 		}
  		return 500;
- 		
- 	}
- 	
- 	@SuppressWarnings("deprecation")
-	public static ItemStack getMainHandItem(Player p) {
- 		
- 		if (versionToNumber() == 18) {
- 			return p.getItemInHand();
- 		} else if (versionToNumber() > 18) {
- 			return p.getInventory().getItemInMainHand();
- 		}
- 		
- 		return p.getItemInHand();
- 		
- 	}
- 	
- 	@SuppressWarnings("deprecation")
-	public static void setMainHandItem(Player p, ItemStack item) {
- 		
- 		if (versionToNumber() == 18) {
- 			p.setItemInHand(item);
- 		} else if (versionToNumber() > 18) {
- 			p.getInventory().setItemInMainHand(item);
- 		} else {
- 			p.setItemInHand(item);
- 		}
- 		
- 	}
- 	
- 	@SuppressWarnings("deprecation")
-	public static ItemStack getOffhandItem(Player p) {
- 		
- 		if (versionToNumber() == 18) {
- 			return p.getItemInHand();
- 		} else if (versionToNumber() > 18) {
- 			return p.getInventory().getItemInOffHand();
- 		}
- 		return p.getItemInHand();
- 		
- 	}
- 	
- 	@SuppressWarnings("deprecation")
-	public static void setOffhandItem(Player p, ItemStack item) {
- 		
- 		if (versionToNumber() == 18) {
- 			p.setItemInHand(item);
- 		} else if (versionToNumber() > 18) {
- 			p.getInventory().setItemInOffHand(item);
- 		} else {
- 			p.setItemInHand(item);
- 		}
- 		
  	}
  	
  	public static List<String> colorizeList(List<String> list) {
- 		
- 		List<String> newList = new ArrayList<String>();
+ 		List<String> newList = new ArrayList<>();
 
  		if (list != null) {
 			for (String string : list) {
@@ -226,35 +156,26 @@ public class Toolkit {
 			}
 			return newList;
 		}
-
  		return null;
- 		
  	}
 
  	public static List<String> replaceInList(List<String> list, String find, String replace) {
-
 		List<String> newList = new ArrayList<>();
 
 		for (String string : list) {
 			newList.add(string.replace(find, replace));
 		}
-
 		return newList;
-
 	}
 
  	public static String toNormalColorCodes(String string) {
-
 		if (string != null) {
 			return string.replace("§", "&");
 		}
-
 		return null;
-
 	}
 
 	public static List<String> toNormalColorCodes(List<String> list) {
-
 		List<String> newList = new ArrayList<>();
 
 		if (list != null) {
@@ -264,22 +185,18 @@ public class Toolkit {
 			return newList;
 		}
 		return null;
-
 	}
 
  	public static Player getPlayer(World world, String name) {
-
 		for (Player player : world.getPlayers()) {
 			if (player.getName().equals(name)) {
 				return player;
 			}
 		}
 		return null;
-
 	}
 
 	public static void saveLocationToResource(Resource resource, String path, Location location) {
-
 		resource.set(path + ".World", location.getWorld().getName());
 		resource.set(path + ".X", location.getBlockX());
 		resource.set(path + ".Y", location.getBlockY());
@@ -287,28 +204,22 @@ public class Toolkit {
 		resource.set(path + ".Yaw", location.getYaw());
 		resource.set(path + ".Pitch", location.getPitch());
 		resource.save();
-
 	}
 
 	public static Location getLocationFromResource(Resource resource, String path) {
-
 		return new Location(Bukkit.getWorld(resource.fetchString(path + ".World")),
 				(float) resource.getInt(path + ".X") + 0.5,
 				(float) resource.getInt(path + ".Y"),
 				(float) resource.getInt(path + ".Z") + 0.5,
 				(float) resource.getDouble(path + ".Yaw"),
 				(float) resource.getDouble(path + ".Pitch"));
-
 	}
 
 	public static String addPlaceholdersIfPossible(Player player, String text) {
-
 		if (Bukkit.getPluginManager().isPluginEnabled("PlaceholderAPI")) {
 			text = PlaceholderAPI.setPlaceholders(player, text);
 		}
-
 		return Toolkit.translate(text);
-
 	}
 
 	// TODO: eventually merge the below two methods into one
@@ -349,53 +260,49 @@ public class Toolkit {
 		return ChatColor.translateAlternateColorCodes('&', s.replace("%prefix%", Game.getPrefix()));
 	}
 
-	public static int getNextAvailable(FileConfiguration yamlConfig, String path, int limit, boolean zeroBased, int fallbackAmount) {
-
+	public static int getNextAvailable(FileConfiguration yamlConfig, String path, int limit, boolean zeroBased,
+									   int fallbackAmount) {
 		for (int i = zeroBased ? 0 : 1; i < limit; i++) {
 			if (!yamlConfig.contains(path + "." + i)) {
 				return i;
 			}
 		}
 		return fallbackAmount;
-
 	}
 
 	public static boolean containsAnyThatStartWith(List<String> list, String valueToTest) {
-
 		for (String string : list) {
 			if (valueToTest.startsWith(string)) {
 				return true;
 			}
 		}
 		return false;
-
 	}
 
 	public static boolean hasMatchingDisplayName(ItemStack item, String targetDisplayName) {
-
 		ItemMeta meta = item.getItemMeta();
 
 		if (item.hasItemMeta() && meta != null) {
 			return meta.hasDisplayName() && Toolkit.translate(meta.getDisplayName()).equals(targetDisplayName);
 		}
-
 		return false;
+	}
 
+	public static boolean hasMatchingMaterial(ItemStack item, String targetMaterial) {
+		return item.getType() == Toolkit.safeMaterial(targetMaterial);
 	}
 
 	public static boolean matchesConfigItem(ItemStack item, Resource resource, String path) {
-
 		ItemMeta itemMeta = item.getItemMeta();
 		String configItemName = resource.fetchString(path + ".Name");
 		String configItemMaterial = resource.fetchString(path + ".Material");
 
-		if (item.getType() == XMaterial.matchXMaterial(configItemMaterial).get().parseMaterial()) {
+		if (Toolkit.hasMatchingMaterial(item, configItemMaterial)) {
 			if (itemMeta != null && itemMeta.hasDisplayName()) {
 				return Toolkit.translate(itemMeta.getDisplayName()).equals(configItemName);
 			}
 		}
 		return false;
-
 	}
 
 	public static void printToConsole(String message) {
@@ -422,20 +329,23 @@ public class Toolkit {
 			assert healthAttribute != null;
 			return (int) healthAttribute.getValue();
 		}
-
 		return (int) p.getMaxHealth();
 	}
 
-	public static ItemStack safeItemStack(String materialName) {
+	public static Material safeMaterial(String materialName) {
 		Optional<XMaterial> materialOptional = XMaterial.matchXMaterial(materialName);
 		if (materialOptional.isPresent()) {
 			Material material = materialOptional.get().parseMaterial();
 			if (material != null) {
-				return new ItemStack(material);
+				return material;
 			}
 		}
 		printToConsole("&7[&b&lKIT-PVP&7] &cInvalid material: " + materialName);
-		return new ItemStack(Toolkit.FALLBACK_MATERIAL);
+		return FALLBACK_MATERIAL;
+	}
+
+	public static ItemStack safeItemStack(String materialName) {
+		return new ItemStack(Toolkit.safeMaterial(materialName));
 	}
 
 	public static Sound safeSound(String soundName) {
@@ -462,23 +372,123 @@ public class Toolkit {
 		return XPotion.BLINDNESS.getPotionEffectType();
 	}
 
-	public static boolean itemStacksMatch(ItemStack itemA, ItemStack itemB) {
-		if (itemA.getType() == itemB.getType()) {
-			ItemMeta itemAMeta = itemA.getItemMeta();
-			ItemMeta itemBMeta = itemB.getItemMeta();
+	@SuppressWarnings("deprecation")
+	public static ItemStack getHandItemForInteraction(Event e) {
+		Player p;
 
-			if (itemAMeta.hasDisplayName() && itemBMeta.hasDisplayName()) {
-				return itemAMeta.getDisplayName().equals(itemBMeta.getDisplayName());
+		if (e instanceof PlayerInteractEvent) {
+			PlayerInteractEvent interactEvent = (PlayerInteractEvent) e;
+			p = interactEvent.getPlayer();
+			if (versionToNumber() == 18) {
+				return p.getItemInHand();
 			}
+
+			return p.getInventory().getItem(interactEvent.getHand() != null ?
+					interactEvent.getHand() : EquipmentSlot.HAND);
+		} else if (e instanceof PlayerInteractEntityEvent) {
+			PlayerInteractEntityEvent interactEntityEvent = (PlayerInteractEntityEvent) e;
+			p = interactEntityEvent.getPlayer();
+			if (versionToNumber() == 18) {
+				return p.getItemInHand();
+			}
+
+			return p.getInventory().getItem(interactEntityEvent.getHand());
+			// ^ no null check needed, there is always a hand with this event
+		}
+		return Toolkit.safeItemStack("AIR");
+	}
+
+	public static void setHandItemForInteraction(Event e, ItemStack item) {
+		Player p;
+
+		if (e instanceof PlayerInteractEvent) {
+			PlayerInteractEvent interactEvent = (PlayerInteractEvent) e;
+			p = interactEvent.getPlayer();
+			if (versionToNumber() == 18) {
+				p.setItemInHand(item);
+				return;
+			}
+
+			p.getInventory().setItem(interactEvent.getHand() != null ?
+					interactEvent.getHand() : EquipmentSlot.HAND, item);
+		} else if (e instanceof PlayerInteractEntityEvent) {
+			PlayerInteractEntityEvent interactEntityEvent = (PlayerInteractEntityEvent) e;
+			p = interactEntityEvent.getPlayer();
+			if (versionToNumber() == 18) {
+				p.setItemInHand(item);
+				return;
+			}
+
+			p.getInventory().setItem(interactEntityEvent.getHand(), item);
+			// ^ no null check needed, there is always a hand with this event
+		}
+	}
+
+	public static boolean eitherHandHasMaterial(Player p, String materialString) {
+		Material materialToFind = XMaterial.matchXMaterial(materialString).get().parseMaterial();
+		if (versionToNumber() == 18) {
+			return p.getItemInHand().getType() == materialToFind;
+		}
+		return p.getInventory().getItemInMainHand().getType() == materialToFind ||
+				p.getInventory().getItemInOffHand().getType() == materialToFind;
+	}
+
+	public static void playSoundToPlayer(Player p, String soundName, int pitch) {
+		p.playSound(p.getLocation(), Toolkit.safeSound(soundName), 1, pitch);
+	}
+
+	public static SlotWrapper getSlotUsedForInteraction(PlayerInteractEvent e) {
+		if (versionToNumber() >= 19) {
+			if (e.getHand() == EquipmentSlot.OFF_HAND) {
+				return new SlotWrapper(e.getHand());
+			}
+		}
+		return new SlotWrapper(e.getPlayer().getInventory().getHeldItemSlot());
+	}
+
+	public static void appendToLore(ItemStack item, String lineToAppend) {
+		ItemMeta itemMeta = item.getItemMeta();
+		if (itemMeta != null) {
+			List<String> newLore = itemMeta.hasLore() ? itemMeta.getLore() : new ArrayList<>();
+			newLore.add(lineToAppend);
+
+			itemMeta.setLore(newLore);
+
+			item.setItemMeta(itemMeta);
+		}
+	}
+
+	public static boolean singleLineLoreMatches(ItemStack item, String expectedLore) {
+		ItemMeta itemMeta = item.getItemMeta();
+		if (itemMeta != null) {
+			return itemMeta.hasLore() && itemMeta.getLore() != null && itemMeta.getLore().get(0).equals(expectedLore);
 		}
 		return false;
 	}
 
-	public static boolean itemUsedIsOffhand(PlayerInteractEvent e) {
-		if (versionToNumber() >= 19) {
-			return e.getHand() == EquipmentSlot.OFF_HAND;
+	public static class SlotWrapper {
+
+		private boolean usesEquipmentSlot = false;
+		private int heldItemSlot = 0;
+		private EquipmentSlot equipmentSlot;
+
+		public SlotWrapper(int heldItemSlot) {
+			this.heldItemSlot = heldItemSlot;
 		}
-		return false;
+
+		public SlotWrapper(EquipmentSlot equipmentSlot) {
+			this.usesEquipmentSlot = true;
+			this.equipmentSlot = equipmentSlot;
+		}
+
+		public void placeItemInSlot(Player p, ItemStack item) {
+			if (usesEquipmentSlot) {
+				p.getInventory().setItem(equipmentSlot, item);
+			} else {
+				p.getInventory().setItem(heldItemSlot, item);
+			}
+		}
+
 	}
 
 }

--- a/src/main/java/com/planetgallium/kitpvp/util/Toolkit.java
+++ b/src/main/java/com/planetgallium/kitpvp/util/Toolkit.java
@@ -14,6 +14,8 @@ import org.bukkit.attribute.AttributeInstance;
 import org.bukkit.configuration.file.FileConfiguration;
 import org.bukkit.entity.Entity;
 import org.bukkit.entity.Player;
+import org.bukkit.event.player.PlayerInteractEvent;
+import org.bukkit.inventory.EquipmentSlot;
 import org.bukkit.inventory.ItemStack;
 
 import com.planetgallium.kitpvp.Game;
@@ -468,6 +470,13 @@ public class Toolkit {
 			if (itemAMeta.hasDisplayName() && itemBMeta.hasDisplayName()) {
 				return itemAMeta.getDisplayName().equals(itemBMeta.getDisplayName());
 			}
+		}
+		return false;
+	}
+
+	public static boolean itemUsedIsOffhand(PlayerInteractEvent e) {
+		if (versionToNumber() >= 19) {
+			return e.getHand() == EquipmentSlot.OFF_HAND;
 		}
 		return false;
 	}

--- a/src/main/java/com/planetgallium/kitpvp/util/Updater.java
+++ b/src/main/java/com/planetgallium/kitpvp/util/Updater.java
@@ -63,7 +63,8 @@ public class Updater {
 
         Bukkit.getScheduler().runTaskAsynchronously(this.javaPlugin, () -> {
             try {
-                HttpURLConnection httpURLConnection = (HttpsURLConnection) new URL(String.format(SPIGOT_URL, this.resourceId)).openConnection();
+                HttpURLConnection httpURLConnection = (HttpsURLConnection) new URL(String.format(SPIGOT_URL,
+                        this.resourceId)).openConnection();
                 httpURLConnection.setRequestMethod("GET");
                 httpURLConnection.setRequestProperty(HttpHeaders.USER_AGENT, "Mozilla/5.0");
 
@@ -71,11 +72,15 @@ public class Updater {
 
                 boolean latestVersion = fetchedVersion.equalsIgnoreCase(this.currentVersion);
 
-                Bukkit.getScheduler().runTask(this.javaPlugin, () -> this.versionResponse.accept(latestVersion ? VersionResponse.LATEST : VersionResponse.FOUND_NEW, latestVersion ? this.currentVersion : fetchedVersion));
+                Bukkit.getScheduler().runTask(this.javaPlugin, () ->
+                        this.versionResponse.accept(latestVersion ? VersionResponse.LATEST : VersionResponse.FOUND_NEW,
+                                latestVersion ? this.currentVersion : fetchedVersion));
             } catch (IOException exception) {
                 exception.printStackTrace();
-                Bukkit.getScheduler().runTask(this.javaPlugin, () -> this.versionResponse.accept(VersionResponse.UNAVAILABLE, null));
+                Bukkit.getScheduler().runTask(this.javaPlugin, () ->
+                        this.versionResponse.accept(VersionResponse.UNAVAILABLE, null));
             }
         });
     }
+
 }

--- a/src/main/java/com/planetgallium/kitpvp/util/WorldGuardAPI.java
+++ b/src/main/java/com/planetgallium/kitpvp/util/WorldGuardAPI.java
@@ -36,7 +36,6 @@ public class WorldGuardAPI {
     }
 
     private boolean allowsWg6(Player player, Location location, StateFlag...flags) {
-
         LocalPlayer localPlayer = WorldGuardPlugin.inst().wrapPlayer(player);
 
         com.sk89q.worldguard.protection.managers.RegionManager regionManager = com.sk89q.worldguard.bukkit.WGBukkit.getRegionManager(location.getWorld());
@@ -55,17 +54,14 @@ public class WorldGuardAPI {
         }
 
         return true;
-
     }
 
     private boolean allowsWg7(Player player, Location location, StateFlag...flags) {
-
         com.sk89q.worldguard.protection.regions.RegionContainer container = com.sk89q.worldguard.WorldGuard.getInstance().getPlatform().getRegionContainer();
         com.sk89q.worldguard.protection.regions.RegionQuery query = container.createQuery();
         ApplicableRegionSet regionSet = query.getApplicableRegions(com.sk89q.worldedit.bukkit.BukkitAdapter.adapt(location));
 
         return regionSet.testState(WorldGuardPlugin.inst().wrapPlayer(player), flags);
-
     }
 
 }

--- a/src/main/java/com/planetgallium/kitpvp/util/WorldGuardFlag.java
+++ b/src/main/java/com/planetgallium/kitpvp/util/WorldGuardFlag.java
@@ -93,7 +93,7 @@ public enum WorldGuardFlag {
     ENTRY_DENY_MESSAGE,
     EXIT_DENY_MESSAGE;
 
-    private byte version = WorldGuardAPI.getInstance().version;
+    private final byte version = WorldGuardAPI.getInstance().version;
     private StateFlag flag;
 
     public StateFlag getFlag() {
@@ -103,7 +103,8 @@ public enum WorldGuardFlag {
         String flagName = name();
 
         try {
-            Class<?> flagClass = version == 6 ? Class.forName("com.sk89q.worldguard.protection.flags.DefaultFlag") : Flags.class;
+            Class<?> flagClass = version == 6 ?
+                    Class.forName("com.sk89q.worldguard.protection.flags.DefaultFlag") : Flags.class;
             flag = (StateFlag) flagClass.getDeclaredField(flagName).get(null);
         } catch (Exception e) {
             System.out.println("[KitPvP] Unsupported flag! WorldGuard version " + version + " ; flag " + flagName);
@@ -112,4 +113,5 @@ public enum WorldGuardFlag {
 
         return flag;
     }
+
 }

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -127,6 +127,7 @@ Arena:
   AbilitiesRequireKit: true
   AddOverflowItemsOnKit: true
   DropRemainingOverflowItemsOnKit: true
+  ResetMaxHealthOnDeath: true
 Other:
   AutomaticallyAddKitToMenu: true
 Spawn:

--- a/src/main/resources/menu.yml
+++ b/src/main/resources/menu.yml
@@ -11,7 +11,7 @@ Menu:
       Name: '&a&lFighter Kit'
       Material: IRON_CHESTPLATE
       Lore:
-      - '&6Ability: &73 Health Packs'
+      - '&6Ability: &7Rechargeable Health Pack'
       - ' '
       - '&7- Iron Sword'
       - '&7- Iron Helmet'
@@ -32,10 +32,10 @@ Menu:
       Lore:
       - '&6Ability: &710 Fire Arrows'
       - ' '
-      - '&7- Wooden Sword'
+      - '&7- Stone Sword'
       - '&7- Bow'
-      - '&7- 32 Arrows'
-      - '&7- Leather Helmet'
+      - '&7- 64 Arrows'
+      - '&7- Chain Helmet'
       - '&7- Chain Chestplate'
       - '&7- Chain Leggings'
       - '&7- Chain Boots'
@@ -51,9 +51,9 @@ Menu:
       Name: '&a&lTank Kit'
       Material: DIAMOND
       Lore:
-      - '&6Ability: &73 Speed Boosts'
+      - '&6Ability: &7Rechargeable Speed Boost'
       - ' '
-      - '&7- Wooden Sword'
+      - '&7- Iron Sword'
       - '&7- Diamond Helmet'
       - '&7- Diamond Chestplate'
       - '&7- Diamond Leggings'
@@ -70,9 +70,9 @@ Menu:
       Name: '&a&lSoldier Kit'
       Material: ARROW
       Lore:
-      - '&6Ability: &75 Guns'
+      - '&6Ability: &7Gun with 5 ammo'
       - ' '
-      - '&7- Iron Sword'
+      - '&7- Stone Sword'
       - '&7- Bow'
       - '&7- 32 Arrows'
       - '&7- Fishing Rod'
@@ -149,7 +149,7 @@ Menu:
         - 'player: kp preview Warper'
     19:
       Name: '&a&lWitch Kit'
-      Material: POTION
+      Material: BREWING_STAND
       Slot: 19
       Lore:
       - '&6Ability: &7Infinite Potions'
@@ -195,8 +195,8 @@ Menu:
       - '&7- Golden Sword'
       - '&7- Leather Helmet'
       - '&7- Golden Chestplate'
-      - '&7- Leather Leggings'
-      - '&7- Leather Boots'
+      - '&7- Golden Leggings'
+      - '&7- Golden Boots'
       - ' '
       - '&eLeft-click to select.'
       - '&eRight-click to preview.'
@@ -228,7 +228,7 @@ Menu:
       Name: '&a&lRhino Kit'
       Material: DIAMOND_HELMET
       Lore:
-      - '&6Ability: &73 Rhino Charges'
+      - '&6Ability: &7Rechargeable Rhino Charge'
       - ' '
       - '&7- Iron Sword'
       - '&7- Diamond Helmet'

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -1,7 +1,7 @@
 name: KitPvP
 author: Cervinakuy
 main: com.planetgallium.kitpvp.Game
-version: 2.2.1
+version: 2.2.2
 description: The ultimate all-in-one KitPvP plugin.
 website: https://www.spigotmc.org/resources/27107/
 softdepend: [PlaceholderAPI, WorldGuard]


### PR DESCRIPTION
v2.2.2
* 1.20.4 support
* Added full offhand support for all plugin items, abilities, etc.
* Added ResetMaxHealthOnDeath arena option
* Fixed ability activators with item amounts greater than 1 not triggering properly
* Fixed some custom abilities not working due to malformed caching
* Fixed custom ability items triggering twice if an item is in the offhand slot
* Fixed some potential SQL conflicts with some other plugins
* Fixed 2 String pathing typos for Preview Menu
* Fixed Leaderboards being reversed
* Fixed players being able to keep inventory items using their cursor after death
* Fixed soup data not refreshing with /kp reload
* Fixed Witch potion ability loopholes
* Fixed menu item color codes in lores sometimes not working
* Removed /kp export for the legacy stats.yml