### PR TITLE
fix: placeholderapi persist

### DIFF
--- a/src/main/java/com/planetgallium/kitpvp/util/Placeholders.java
+++ b/src/main/java/com/planetgallium/kitpvp/util/Placeholders.java
@@ -78,7 +78,10 @@ public class Placeholders extends PlaceholderExpansion {
 	
 	@Override
 	public boolean canRegister() { return true; }
-	
+
+	@Override
+	public boolean persist() { return true; }
+
 	@Override
 	public @NotNull String getAuthor() { return "Cervinakuy"; }
 	


### PR DESCRIPTION
This PR set `persist()` to true, so the expansion won't be unregistered after /papi reload.