### PR TITLE
v2.2.4

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -140,7 +140,7 @@
         <dependency>
             <groupId>com.github.cryptomorin</groupId>
             <artifactId>XSeries</artifactId>
-            <version>9.10.0</version>
+            <version>11.2.1</version>
             <scope>compile</scope>
         </dependency>
         <dependency>

--- a/src/main/java/com/planetgallium/kitpvp/command/MainCommand.java
+++ b/src/main/java/com/planetgallium/kitpvp/command/MainCommand.java
@@ -18,6 +18,7 @@ import org.bukkit.potion.PotionEffect;
 import org.bukkit.scheduler.BukkitRunnable;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 
 public class MainCommand implements CommandExecutor {
@@ -214,17 +215,23 @@ public class MainCommand implements CommandExecutor {
     }
 
     private void executeDebugCommand(CommandSender sender) {
-        String names = "";
+        List<String> specialPlugins = Arrays.asList("PerWorldPlugins", "AuthMe");
+
+        StringBuilder names = new StringBuilder();
 
         for (Plugin plugin : Bukkit.getPluginManager().getPlugins()) {
-            names += plugin.getName() + " ";
+            String pluginName = plugin.getName();
+            if (specialPlugins.contains(pluginName) || pluginName.toLowerCase().contains("auth")) {
+                names.append("&c");
+            }
+            names.append(plugin.getName()).append(" ");
         }
 
         String serverVersion = Bukkit.getBukkitVersion() + " " +
                 (Bukkit.getVersion().contains("Spigot") ? "(Spigot)" : "(Other)");
         String pluginVersion = plugin.getDescription().getVersion() + " " +
-                (plugin.needsUpdate() ? "&c(Requires Update)" : "&a(Latest Version)");
-        String isSpawnSet = (config.contains("Arenas") ? "&aConfigured" : "&cUnconfigured");
+                (plugin.needsUpdate() ? "&c(Requires Update)" : "&e(Latest Version)");
+        String isSpawnSet = (config.contains("Arenas") ? "&eConfigured" : "&cUnconfigured");
 
         sender.sendMessage(Toolkit.translate("&7[&b&lKIT-PVP&7] &aServer Version: &7" + serverVersion));
         sender.sendMessage(Toolkit.translate("&7[&b&lKIT-PVP&7] &aPlugin Version: &7" + pluginVersion));

--- a/src/main/java/com/planetgallium/kitpvp/item/AttributeParser.java
+++ b/src/main/java/com/planetgallium/kitpvp/item/AttributeParser.java
@@ -73,14 +73,31 @@ public class AttributeParser {
 
         if (resource.contains(path + ".Material")) {
             String materialValue = resource.fetchString(path + ".Material");
-            Optional<XMaterial> possibleMaterial = XMaterial.matchXMaterial(materialValue);
 
-            if (possibleMaterial.isPresent()) {
-                item.setType(possibleMaterial.get().parseMaterial());
-            } else {
-                Toolkit.printToConsole(String.format("&7[&b&lKIT-PVP&7] &cUnknown material [%s], defaulting to [%s].",
-                                                     materialValue, FALLBACK_ITEM_MATERIAL));
+            // First try to match on native server version Material; should allow
+            // for dynamically supporting new items in newer server versions
+
+            Material possibleNativeMaterial;
+            try {
+                possibleNativeMaterial = Material.valueOf(materialValue);
+            } catch (IllegalArgumentException exception) {
+                possibleNativeMaterial = null;
             }
+
+            if (possibleNativeMaterial != null) {
+                item.setType(possibleNativeMaterial);
+            } else {
+                // If no match, use XMaterial before defaulting to bedrock
+                Optional<XMaterial> possibleMaterial = XMaterial.matchXMaterial(materialValue);
+
+                if (possibleMaterial.isPresent()) {
+                    item.setType(possibleMaterial.get().parseMaterial());
+                } else {
+                    Toolkit.printToConsole(String.format("&7[&b&lKIT-PVP&7] &cUnknown material [%s], defaulting to [%s].",
+                            materialValue, FALLBACK_ITEM_MATERIAL));
+                }
+            }
+
         }
 
         if (resource.contains(path + ".Amount")) {

--- a/src/main/java/com/planetgallium/kitpvp/item/AttributeParser.java
+++ b/src/main/java/com/planetgallium/kitpvp/item/AttributeParser.java
@@ -72,32 +72,10 @@ public class AttributeParser {
         }
 
         if (resource.contains(path + ".Material")) {
-            String materialValue = resource.fetchString(path + ".Material");
+            String materialName = resource.fetchString(path + ".Material");
+            Material material = Toolkit.safeMaterial(materialName);
 
-            // First try to match on native server version Material; should allow
-            // for dynamically supporting new items in newer server versions
-
-            Material possibleNativeMaterial;
-            try {
-                possibleNativeMaterial = Material.valueOf(materialValue);
-            } catch (IllegalArgumentException exception) {
-                possibleNativeMaterial = null;
-            }
-
-            if (possibleNativeMaterial != null) {
-                item.setType(possibleNativeMaterial);
-            } else {
-                // If no match, use XMaterial before defaulting to bedrock
-                Optional<XMaterial> possibleMaterial = XMaterial.matchXMaterial(materialValue);
-
-                if (possibleMaterial.isPresent()) {
-                    item.setType(possibleMaterial.get().parseMaterial());
-                } else {
-                    Toolkit.printToConsole(String.format("&7[&b&lKIT-PVP&7] &cUnknown material [%s], defaulting to [%s].",
-                            materialValue, FALLBACK_ITEM_MATERIAL));
-                }
-            }
-
+            item.setType(material);
         }
 
         if (resource.contains(path + ".Amount")) {

--- a/src/main/java/com/planetgallium/kitpvp/listener/ItemListener.java
+++ b/src/main/java/com/planetgallium/kitpvp/listener/ItemListener.java
@@ -26,6 +26,7 @@ import org.bukkit.event.player.PlayerInteractEntityEvent;
 import org.bukkit.event.player.PlayerInteractEvent;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.meta.ItemMeta;
+import org.bukkit.inventory.meta.PotionMeta;
 import org.bukkit.potion.Potion;
 import org.bukkit.potion.PotionEffect;
 import org.bukkit.potion.PotionEffectType;
@@ -33,7 +34,6 @@ import org.bukkit.potion.PotionType;
 import org.bukkit.scheduler.BukkitRunnable;
 import org.bukkit.util.Vector;
 
-import java.util.Objects;
 import java.util.Random;
 
 public class ItemListener implements Listener {
@@ -502,16 +502,31 @@ public class ItemListener implements Listener {
 	}
 
 	private ItemStack createWitchPotion() {
-		Potion potion = new Potion(pickPotion(), 1);
-		potion.setSplash(true);
+		PotionType randomPotionType = randomPotionType();
 
-		ItemStack potionStack = potion.toItemStack(1);
-		Toolkit.appendToLore(potionStack, "X");
+		if (Toolkit.versionToNumber() >= 121) { // 1.21+
+			ItemStack potionStack = new ItemStack(Material.SPLASH_POTION);
+			Toolkit.appendToLore(potionStack, "X");
+			PotionMeta potionMeta = (PotionMeta) potionStack.getItemMeta();
 
-		return potionStack;
+			if (potionMeta != null) {
+				potionMeta.setBasePotionType(randomPotionType);
+				potionStack.setItemMeta(potionMeta);
+			}
+
+			return potionStack;
+		} else { // pre 1.21
+			Potion potion = new Potion(randomPotionType, 1);
+			potion.setSplash(true);
+
+			ItemStack potionStack = potion.toItemStack(1);
+			Toolkit.appendToLore(potionStack, "X");
+
+			return potionStack;
+		}
 	}
 	
-	private PotionType pickPotion() {
+	private PotionType randomPotionType() {
 		PotionType potion = null;
 		
 		Random ran = new Random();

--- a/src/main/java/com/planetgallium/kitpvp/listener/SignListener.java
+++ b/src/main/java/com/planetgallium/kitpvp/listener/SignListener.java
@@ -81,9 +81,11 @@ public class SignListener implements Listener {
 
 					if (mismatchedLines.size() == 0) { // exact match
 						executeSign(p, signType, null);
+						e.setCancelled(true); // prevents sign editing on 1.20+
 						break;
 					} else if (mismatchedLines.size() == 1) { // one line (line with kit name or arena name) doesn't match
 						executeSign(p, signType, getWordDelta(mismatchedLines));
+						e.setCancelled(true); // prevents sign editing on 1.20+
 						break;
 					}
 				}

--- a/src/main/java/com/planetgallium/kitpvp/util/Toolkit.java
+++ b/src/main/java/com/planetgallium/kitpvp/util/Toolkit.java
@@ -337,6 +337,7 @@ public class Toolkit {
 	}
 
 	public static Material safeMaterial(String materialName) {
+		// 1. Use XMaterial first
 		Optional<XMaterial> materialOptional = XMaterial.matchXMaterial(materialName);
 		if (materialOptional.isPresent()) {
 			Material material = materialOptional.get().parseMaterial();
@@ -344,7 +345,16 @@ public class Toolkit {
 				return material;
 			}
 		}
-		printToConsole("&7[&b&lKIT-PVP&7] &cInvalid material: " + materialName);
+
+		// 2. XMaterial fails, try native check before returning fallbackMaterial (forward-compatible)
+		Material potentialNativeMaterial = Material.getMaterial(materialName);
+		if (potentialNativeMaterial != null) {
+			return potentialNativeMaterial;
+		}
+
+		// 3. Native check fails; return fallbackMaterial
+		printToConsole(String.format("&7[&b&lKIT-PVP&7] &cUnknown material [%s], defaulting to [%s].",
+				materialName, FALLBACK_MATERIAL));
 		return FALLBACK_MATERIAL;
 	}
 

--- a/src/main/java/com/planetgallium/kitpvp/util/Toolkit.java
+++ b/src/main/java/com/planetgallium/kitpvp/util/Toolkit.java
@@ -145,6 +145,8 @@ public class Toolkit {
 			return 119;
 		} else if (version.contains("1.20")) {
 			return 120;
+		} else if (version.contains("1.21")) {
+			return 121;
 		}
  		return 500;
  	}

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -1,7 +1,7 @@
 name: KitPvP
 author: Cervinakuy
 main: com.planetgallium.kitpvp.Game
-version: 2.2.3
+version: 2.2.4
 description: The ultimate all-in-one KitPvP plugin.
 website: https://www.spigotmc.org/resources/27107/
 softdepend: [PlaceholderAPI, WorldGuard]


### PR DESCRIPTION
- 1.21 support
- Forward compatibility for items/materials in future server versions
- Fix 1.20+ opening sign editing when interacting with KitPvP signs
- Fixed Witch Potion Switcher not working on 1.21+ (NoClassDefFoundError org/bukkit/potion/Potion error)